### PR TITLE
fix: Clean build directory before running build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "raw-loader": "^0.5.1",
     "recursive-copy": "^2.0.6",
     "replace-bundle-webpack-plugin": "^1.0.0",
+    "rimraf": "^2.6.1",
     "script-ext-html-webpack-plugin": "^1.8.0",
     "simplehttp2server": "^1.0.0",
     "sw-precache-webpack-plugin": "^0.11.0",

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -89,7 +89,6 @@ export default asyncCommand({
 
 		pkg.scripts = {
 			start: 'if-env NODE_ENV=production && npm run -s serve || npm run -s dev',
-			prebuild: 'rimraf build',
 			build: 'preact build',
 			serve: 'preact build && preact serve',
 			dev: 'preact watch',
@@ -108,8 +107,7 @@ export default asyncCommand({
 			'install', '--save-dev',
 			'preact-cli',
 			'if-env',
-			'eslint',
-			'rimraf'
+			'eslint'
 		]);
 
 		spinner.text = 'Installing dependencies';

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -89,6 +89,7 @@ export default asyncCommand({
 
 		pkg.scripts = {
 			start: 'if-env NODE_ENV=production && npm run -s serve || npm run -s dev',
+			prebuild: 'rimraf build',
 			build: 'preact build',
 			serve: 'preact build && preact serve',
 			dev: 'preact watch',
@@ -107,7 +108,8 @@ export default asyncCommand({
 			'install', '--save-dev',
 			'preact-cli',
 			'if-env',
-			'eslint'
+			'eslint',
+			'rimraf'
 		]);
 
 		spinner.text = 'Installing dependencies';

--- a/src/lib/run-webpack.js
+++ b/src/lib/run-webpack.js
@@ -1,6 +1,7 @@
 import webpack from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import chalk from 'chalk';
+import rimraf from 'rimraf';
 
 export default (watch=false, config, onprogress) => new Promise( (resolve, reject) => {
 	let compiler = webpack(config);
@@ -31,7 +32,9 @@ export default (watch=false, config, onprogress) => new Promise( (resolve, rejec
 		server.listen(config.devServer.port);
 	}
 	else {
-		compiler.run(done);
+		cleanOutputDir(config)
+			.catch(reject)
+			.then(() => compiler.run(done));
 	}
 });
 
@@ -51,4 +54,14 @@ export function showStats(stats) {
 	}
 
 	return stats;
+}
+
+const cleanOutputDir = config => {
+	let output = config.output.path
+	return new Promise((resolve, reject) => {
+		rimraf(output, err => {
+			if (err) reject(err)
+			resolve()
+		})
+	})
 }


### PR DESCRIPTION
Build directory is not cleaned before each successive build. This causes redundant file leftovers between builds.

As title describes - this fixes that by using rimraf via prebuild hook in created package.json