### PR TITLE
fix: Throw error for unknown command

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -92,7 +92,7 @@ export default asyncCommand({
 			build: 'preact build',
 			serve: 'preact build && preact serve',
 			dev: 'preact watch',
-			test: 'eslint src && echo "Error: no test specified" && exit 1'
+			test: 'eslint src && preact test'
 		};
 
 		pkg.eslintConfig = {

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -92,7 +92,7 @@ export default asyncCommand({
 			build: 'preact build',
 			serve: 'preact build && preact serve',
 			dev: 'preact watch',
-			test: 'eslint src && preact test'
+			test: 'eslint src && echo "Error: no test specified" && exit 1'
 		};
 
 		pkg.eslintConfig = {

--- a/src/index.js
+++ b/src/index.js
@@ -22,4 +22,5 @@ yargs
 	.help()
 	.alias('h', 'help')
 	.demandCommand()
+	.strict()
 	.argv;


### PR DESCRIPTION
Currenty runing ```preact whatever``` won't report error. This is kinda unexpected behaviour and might cause some harm, e.g. in CI environments where script like ```preact built``` will return exit code 0.

This PR fixes that. I've also took liberty in changing default test script (coz ```preact test``` won't work now and people might get confused).

Pictures coz a picture is worth a thousand words.
Before:
<img width="235" alt="screen shot 2017-05-20 at 16 17 50" src="https://cloud.githubusercontent.com/assets/7580355/26276468/6f1645fa-3d78-11e7-9edf-bac860b51fdb.png">

After:
<img width="683" alt="screen shot 2017-05-20 at 16 17 53" src="https://cloud.githubusercontent.com/assets/7580355/26276474/7a518c7c-3d78-11e7-9cdf-c4eb56bcbf4e.png">


