### PR TITLE
Fix Babel Builds

### DIFF
--- a/src/lib/babel-config.js
+++ b/src/lib/babel-config.js
@@ -1,4 +1,5 @@
 export default (env, options={}) => ({
+	babelrc: false,
 	presets: [
 		[require.resolve('babel-preset-env'), {
 			loose: true,

--- a/src/lib/webpack-config.js
+++ b/src/lib/webpack-config.js
@@ -105,7 +105,6 @@ export default env => {
 					pkg = readJson(manifest) || {};
 				return !!(pkg.module || pkg['jsnext:main']);
 			},
-			babelrc: false,
 			...createBabelConfig(env)
 		}),
 

--- a/src/lib/webpack-config.js
+++ b/src/lib/webpack-config.js
@@ -98,7 +98,6 @@ export default env => {
 
 		// ES2015
 		babel({
-			exclude: [],
 			include(filepath) {
 				if (filepath.indexOf(src('.'))===0 || filepath.indexOf(resolve(__dirname, '../..'))===0 || filepath.split(/[/\\]/).indexOf('node_modules')===-1) return true;
 				let manifest = resolve(filepath.replace(/(.*([\/\\]node_modules|\.\.)[\/\\](@[^\/\\]+[\/\\])?[^\/\\]+)([\/\\].*)?$/g, '$1'), 'package.json'),


### PR DESCRIPTION
For whatever reason (Babel internals, I assume), passing `exclude:[]` made (1) Babel ignore `babelrc:false` and (2) prevented the `env` preset from resolving/determining what plugins & presets it had to work with.

This core of the fix is _only_ removing the `exclude` setting. Moving `babelrc` was mostly an aesthetic thing, I guess.

Closes #9 