### PR TITLE
Fix async components diffing

### DIFF
--- a/src/components/async.js
+++ b/src/components/async.js
@@ -10,6 +10,7 @@ export default function(load) {
 		if (r && r.then) r.then(done);
 	}
 	Async.prototype = new Component;
+	Async.prototype.constructor = Async;
 	Async.prototype.render = (props, state) => h(state.child, props);
 	return Async;
 }


### PR DESCRIPTION
We have to define the class `constructor`, else async components are recreated everytime the parent rerenders.

Technical details: if not defined on the `Async` class, the property `constructor` is inherited from `Component`, and preact does not find the actual `Async` constructor in `buildComponentFromVNode`, so it doesn't find the component owner, so the component is recreated.

I made a gist if you want to reproduce 😄 https://gist.github.com/BenoitZugmeyer/67b44e172a44d013290d25b62052f207