### PR TITLE
Expose compiler object responsible for compiling the preact application

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "preact-cli",
   "version": "1.1.0",
   "description": "Start building a Preact Progressive Web App in seconds.",
-  "main": "lib/index.js",
+  "main": "lib/compiler.js",
   "bin": {
     "preact": "./lib/index.js"
   },

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -1,9 +1,5 @@
-import { resolve } from 'path';
-import promisify from 'es6-promisify';
-import rimraf from 'rimraf';
 import asyncCommand from '../lib/async-command';
-import webpackConfig from '../lib/webpack-config';
-import runWebpack, { showStats, writeJsonStats } from '../lib/run-webpack';
+import createCompiler from '../compiler';
 
 export default asyncCommand({
 	command: 'build [src] [dest]',
@@ -39,18 +35,16 @@ export default asyncCommand({
 	},
 
 	async handler(argv) {
-		let config = webpackConfig(argv);
+		let compiler = createCompiler(argv);
 
 		if (argv.clean) {
-			let dest = resolve(argv.cwd || process.cwd(), argv.dest || 'build');
-			await promisify(rimraf)(dest);
+			await compiler.clean();
 		}
 
-		let stats = await runWebpack(false, config);
-		showStats(stats);
+		await compiler.compile();
 
 		if (argv.json) {
-			await writeJsonStats(stats);
+			await compiler.stats();
 		}
 	}
 });

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -41,10 +41,10 @@ export default asyncCommand({
 			await compiler.clean();
 		}
 
-		await compiler.compile();
+		let stats = await compiler.compile();
 
 		if (argv.json) {
-			await compiler.stats();
+			await compiler.writeJsonStats(stats);
 		}
 	}
 });

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -1,6 +1,5 @@
 import asyncCommand from '../lib/async-command';
-import webpackConfig from '../lib/webpack-config';
-import runWebpack, { showStats } from '../lib/run-webpack';
+import createCompiler from '../compile';
 
 export default asyncCommand({
 	command: 'watch [src]',
@@ -35,9 +34,7 @@ export default asyncCommand({
 
 	async handler(argv) {
 		argv.production = false;
-		let config = webpackConfig(argv);
 
-		let stats = await runWebpack(true, config, showStats);
-		showStats(stats);
+		await createCompiler(argv).compile(true);
 	}
 });

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,0 +1,36 @@
+import { resolve } from 'path';
+import promisify from 'es6-promisify';
+import rimraf from 'rimraf';
+import prerender from './lib/prerender';
+import webpackConfig from './lib/webpack-config';
+import runWebpack, { showStats } from './lib/run-webpack';
+
+class Compiler {
+	constructor(env = {}) {
+		this.env = env;
+		this.config = webpackConfig(env);
+		this.stats = null;
+	}
+
+	async clean() {
+		let dest = resolve(this.env.cwd || process.cwd(), this.env.dest || 'build');
+		await promisify(rimraf)(dest);
+	}
+
+	async compile(watch = false) {
+		this.stats = await runWebpack(watch, this.config, showStats);
+		showStats(this.stats);
+	}
+
+	prerender(params) {
+		return prerender(this.env, params);
+	}
+
+	async stats() {
+		await writeJsonStats(stats);
+	}
+}
+
+export default env => {
+	return new Compiler(env);
+}

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -3,34 +3,30 @@ import promisify from 'es6-promisify';
 import rimraf from 'rimraf';
 import prerender from './lib/prerender';
 import webpackConfig from './lib/webpack-config';
-import runWebpack, { showStats } from './lib/run-webpack';
-
-class Compiler {
-	constructor(env = {}) {
-		this.env = env;
-		this.config = webpackConfig(env);
-		this.stats = null;
-	}
-
-	async clean() {
-		let dest = resolve(this.env.cwd || process.cwd(), this.env.dest || 'build');
-		await promisify(rimraf)(dest);
-	}
-
-	async compile(watch = false) {
-		this.stats = await runWebpack(watch, this.config, showStats);
-		showStats(this.stats);
-	}
-
-	prerender(params) {
-		return prerender(this.env, params);
-	}
-
-	async stats() {
-		await writeJsonStats(stats);
-	}
-}
+import runWebpack, { showStats, writeJsonStats } from './lib/run-webpack';
 
 export default env => {
-	return new Compiler(env);
+	let config = webpackConfig(env)
+
+	return {
+		async clean() {
+			let dest = resolve(env.cwd || process.cwd(), env.dest || 'build');
+			await promisify(rimraf)(dest);
+		}
+
+		async compile(watch = false) {
+			let stats = await runWebpack(watch, config, showStats);
+			showStats(stats);
+
+			return stats;
+	 	}
+
+	 	prerender(params) {
+			return prerender(env, params);
+		}
+
+		async writeJsonStats(stats) {
+			await writeJsonStats(stats);
+		}
+	}
 }

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -25,8 +25,8 @@ export default env => {
 			return prerender(env, params);
 		}
 
-		async writeJsonStats(stats) {
-			await writeJsonStats(stats);
+		writeJsonStats(stats) {
+			return writeJsonStats(stats);
 		}
 	}
 }


### PR DESCRIPTION
As mentioned by #70, I started creating a reusable compiler instance responsible for building or watching a preact application. The commands are now using this compiler to generate their output. The compiler is exposed as main entry so one can use it in their own project like this;

```js
const createCompiler = require('preact-cli');

let compiler = createCompiler(/* any options can be passed here */);

// Compile the application and optionally serve it through the dev server by passing a bool.
await compiler.compile(true);

// Return a prerendered string for the given params
compiler.prerender(/* any params passed to prerender */)
```

I guess this can be seen as a first step in exposing an api to built upon; like exposing the prerender functionality to render compiled preact strings in a node.js app, replacing the dev server with dev middleware so you can mount the preact-cli on your own server, etc.