### PR TITLE
Use un-minified Preact in DEV mode

### DIFF
--- a/src/lib/webpack-config.js
+++ b/src/lib/webpack-config.js
@@ -78,7 +78,7 @@ export default env => {
 					'preact-cli-entrypoint': src('index.js'),
 					'preact-cli-polyfills': resolve(__dirname, 'polyfills.js'),
 					style: src('style'),
-					preact$: 'preact/dist/preact.min.js',
+					preact$: isProd ? 'preact/dist/preact.min.js' : 'preact'
 					// preact-compat aliases for supporting React dependencies:
 					react: 'preact-compat',
 					'react-dom': 'preact-compat',


### PR DESCRIPTION
This is to prevent cryptic stack trace like this 

```
Uncaught TypeError: Cannot read property '_renderedComponent' of undefined
    at visitNonCompositeChildren (eval at ./cli/node_modules/preact/devtools.js (app.925b01a….js:912), <anonymous>:209:16)
    at Object.componentUpdated (eval at ./cli/node_modules/preact/devtools.js (app.925b01a….js:912), <anonymous>:151:4)
    at Object.preact.options.afterUpdate (eval at ./cli/node_modules/preact/devtools.js (app.925b01a….js:912), <anonymous>:237:11)
    at k (eval at ./cli/node_modules/preact/dist/preact.min.js (app.925b01a….js:920), <anonymous>:159:122)
    at i (eval at ./cli/node_modules/preact/dist/preact.min.js (app.925b01a….js:920), <anonymous>:28:16)
```