### PR TITLE
Bump simplehttp2server

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "replace-bundle-webpack-plugin": "^1.0.0",
     "rimraf": "^2.6.1",
     "script-ext-html-webpack-plugin": "^1.8.0",
-    "simplehttp2server": "^1.0.0",
+    "simplehttp2server": "^2.0.0",
     "sw-precache-webpack-plugin": "^0.11.0",
     "tmp": "0.0.31",
     "unfetch": "^2.1.2",


### PR DESCRIPTION
related #26 
Now `simplehttp2server` use precompiled binary from [original releases](https://github.com/GoogleChrome/simplehttp2server/releases).