### PR TITLE
Changed —type option name to match CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ preact create
   --name      directory and package name for the new app
   --dest      Directory to create the app within                  [default: <name>]
   --type      A project template to start from
-              [Options: "default", "full", "simple", "empty"]     [default: "default"]
+              [Options: "default", "root", "simple", "empty"]     [default: "default"]
   --less      Pre-install LESS support                 [boolean]  [default: false]
   --sass      Pre-install SASS/SCSS support            [boolean]  [default: false]
 


### PR DESCRIPTION
Reflecting the CLI change of 'full' to 'root' of --type options in the README.