### PR TITLE
tests: Preact CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ preact create
   --name      directory and package name for the new app
   --dest      Directory to create the app within                  [default: <name>]
   --type      A project template to start from
-              [Options: "default", "full", "simple", "empty"]     [default: "default"]
+              [Options: "default", "root", "simple", "empty"]     [default: "default"]
   --less      Pre-install LESS support                 [boolean]  [default: false]
   --sass      Pre-install SASS/SCSS support            [boolean]  [default: false]
 

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -35,6 +35,9 @@ export default asyncCommand({
 		json: {
 			description: 'Generate build statistics for analysis.',
 			default: false
+		},
+		template: {
+			description: 'HTML template used by webpack'
 		}
 	},
 

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -30,6 +30,9 @@ export default asyncCommand({
 		prerender: {
 			description: 'Pre-render static app content on initial build',
 			default: false
+		},
+		template: {
+			description: 'HTML template used by webpack'
 		}
 	},
 


### PR DESCRIPTION
Basic tests for every command CLI exposes :tada:

Stuff used:
- Headless chrome (which requires Chrome > 59)
- Tape - Jest had problems with running Chrome, Ava had problems with spawning - tests are kinda slow without concurrency (~1m on my laptop).

