### PR TITLE
Add create-react-class to preact-compat Webpack settings

### DIFF
--- a/src/lib/webpack-config.js
+++ b/src/lib/webpack-config.js
@@ -81,6 +81,7 @@ export default env => {
 					// preact-compat aliases for supporting React dependencies:
 					react: 'preact-compat',
 					'react-dom': 'preact-compat',
+					'create-react-class': 'preact-compat/lib/create-react-class',
 					'react-addons-css-transition-group': 'preact-css-transition-group'
 				}
 			},


### PR DESCRIPTION
I was just wondering why I couldn't use https://github.com/JedWatson/react-select until I discovered this was missing.