### PR TITLE
Still generate push manifest when there's no Router

### DIFF
--- a/src/lib/webpack/push-manifest.js
+++ b/src/lib/webpack/push-manifest.js
@@ -1,23 +1,28 @@
 module.exports = class PushManifestPlugin {
 	apply(compiler) {
 		compiler.plugin('emit', function(compilation, callback) {
-			let manifest = {};
+			let defaults = {
+					'style.css': {
+						type: 'style',
+						weight: 1
+					},
+					'bundle.js': {
+						type: 'script',
+						weight: 1
+					},
+				},
+				manifest = {
+					'/': defaults
+				};
 
 			for (let filename in compilation.assets) {
 				if (/route-/.test(filename) && !/\.map$/.test(filename)) {
 					let path = filename.replace(/route-/, '/').replace(/\.chunk(\.\w+)?\.js$/, '').replace(/\/home/, '/');
 					manifest[path] = {
-						"style.css": {
-							"type": "style",
-							"weight": 1
-						},
-						"bundle.js": {
-							"type": "script",
-							"weight": 1
-						},
+						...defaults,
 						[filename]: {
-							"type": "script",
-							"weight": .9
+							type: 'script',
+							weight: .9
 						}
 					};
 				}

--- a/tests/build.snapshot.js
+++ b/tests/build.snapshot.js
@@ -9,7 +9,7 @@ const smallBuildCommons = {
 	'favicon.ico': { size: 15086 },
 	'sw.js': { size: 3330 },
 	'manifest.json': { size: 298 },
-	'push-manifest.json': { size: 2 },
+	'push-manifest.json': { size: 88 },
 };
 
 const fullBuildCommons = {


### PR DESCRIPTION
When there's no `Router`, still generate a push manifest entry for `/`. Fixes #154.