### PR TITLE
Declare Node v6 as minimum support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
     ["env", {
       "loose": true,
       "targets": {
-        "node": 4
+        "node": 6
       },
       "exclude": [
         "transform-regenerator"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ addons:
 
 language: node_js
 node_js:
-  - "6"
-  - "7"
-  - "8"
+  - 6
+  - 8
 cache:
   npm: true
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "preact-cli",
   "version": "1.3.0",
   "description": "Start building a Preact Progressive Web App in seconds.",
+  "repository": "developit/preact-cli",
   "main": "lib/index.js",
   "bin": {
     "preact": "./lib/index.js"
@@ -21,7 +22,9 @@
     "test:watch": "babel-node src watch --cwd examples/root --port 3000",
     "test:deploy": "npm run test:build && cp examples/root/build/index.html examples/root/build/200.html && surge -d cli-demo.preactjs.com examples/root/build"
   },
-  "repository": "developit/preact-cli",
+  "engines": {
+    "node": ">=6"
+  },
   "files": [
     "lib",
     "examples"


### PR DESCRIPTION
The `engines` key will only show a warning to NPM installers. It's not perfect, but at least it's something.

Although we were compiling to Node 4 and _our_ code worked in a Node 4 environment (I just tried, dat `npm install` doe...💤 ), we have several dependencies that require 5+ and 6+ _and_ our dependency resolution was fighting against NPM's dependency tree (typical).

So with this, we're now compiling to Node 6 & actively declaring a 6+ minimum.

I removed Node 7 from Travis because we're already testing v8 and v7 literally brings nothing unique to the table. This will make tests completely a bit sooner.

References #165 