### PR TITLE
Expose development server network interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "fs.promised": "^3.0.0",
     "html-webpack-exclude-assets-plugin": "0.0.5",
     "html-webpack-plugin": "^2.28.0",
+    "ip": "^1.1.5",
     "isomorphic-unfetch": "^2.0.0",
     "json-loader": "^0.5.4",
     "less": "^2.7.2",

--- a/src/lib/webpack/run-webpack.js
+++ b/src/lib/webpack/run-webpack.js
@@ -27,8 +27,14 @@ const devBuild = async (env, onprogress) => {
 			if (first) {
 				first = false;
 				let devServer = config.devServer;
-				let serverAddr = `${devServer.https?'https':'http'}://${process.env.HOST || devServer.host || 'localhost'}:${process.env.PORT || devServer.port || 8080}`;
-				let localIpAddr = `${devServer.https?'https':'http'}://${ip.address()}:${process.env.PORT || devServer.port || 8080}`;
+
+				let protocol = devServer.https ? 'https' : 'http';
+				let host = process.env.HOST || devServer.host || 'localhost';
+				let port = process.env.PORT || devServer.port || 8080;
+
+				let serverAddr = `${protocol}://${host}:${port}`;
+				let localIpAddr = `${protocol}://${ip.address()}:${port}`;
+
 				process.stdout.write(chalk.green('Compiled successfully!!\n\n'));
 				process.stdout.write('You can view the application in the browser.\n\n');
 				process.stdout.write(`${chalk.bold('Local:')}            ${serverAddr}\n`);

--- a/src/lib/webpack/run-webpack.js
+++ b/src/lib/webpack/run-webpack.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs.promised';
+import ip from 'ip';
 import webpack from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import chalk from 'chalk';
@@ -27,7 +28,11 @@ const devBuild = async (env, onprogress) => {
 				first = false;
 				let devServer = config.devServer;
 				let serverAddr = `${devServer.https?'https':'http'}://${process.env.HOST || devServer.host || 'localhost'}:${process.env.PORT || devServer.port || 8080}`;
-				process.stdout.write(`  \u001b[32m> Development server started at ${serverAddr}\u001b[39m\n`);
+				let localIpAddr = `${devServer.https?'https':'http'}://${ip.address()}:${process.env.PORT || devServer.port || 8080}`;
+				process.stdout.write(chalk.green('Compiled successfully!!\n\n'));
+				process.stdout.write('You can view the application in the browser.\n\n');
+				process.stdout.write(`${chalk.bold('Local:')}            ${serverAddr}\n`);
+				process.stdout.write(`${chalk.bold('On Your Network:')}  ${localIpAddr}\n`);
 			}
 			if (onprogress) onprogress(stats);
 		});


### PR DESCRIPTION
Exposes network address for development build (fix #170)

This is how it looks now:
<img width="847" alt="image 2017-07-02 at 2 13 33 pm" src="https://user-images.githubusercontent.com/3415488/27768433-1db70016-5f31-11e7-81c6-5fd8cb5ea03e.png">
