### PR TITLE
removed boolean check for running dev server in https

### DIFF
--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -19,8 +19,7 @@ export default asyncCommand({
 		},
 		host: {
 			description: 'Hostname to start a server on',
-			default: '0.0.0.0',
-			alias: 'h'
+			default: '0.0.0.0'
 		},
 		https: {
 			description: 'Use HTTPS?',

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -19,7 +19,8 @@ export default asyncCommand({
 		},
 		host: {
 			description: 'Hostname to start a server on',
-			default: '0.0.0.0'
+			default: '0.0.0.0',
+			alias: 'h'
 		},
 		https: {
 			description: 'Use HTTPS?',

--- a/src/lib/webpack/webpack-client-config.js
+++ b/src/lib/webpack/webpack-client-config.js
@@ -123,7 +123,7 @@ const development = config => {
 			host,
 			inline: true,
 			hot: true,
-			https: config.https===true,
+			https: config.https,
 			compress: true,
 			publicPath: '/',
 			contentBase: resolve(config.cwd, config.src || './src'),


### PR DESCRIPTION
Removed boolean check for running dev server in https from [here](https://github.com/developit/preact-cli/blob/2bd02cb8e5c442c0987d90d6cada3a91516fa790/src/lib/webpack/webpack-client-config.js#L126)

Now you can run dev server in `HTTPS`

Fix for bug #175 
