### PR TITLE
enabling create app in current directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "get-port": "^3.1.0",
     "html-webpack-exclude-assets-plugin": "0.0.5",
     "html-webpack-plugin": "^2.28.0",
+    "inquirer": "^3.2.0",
     "ip": "^1.1.5",
     "isomorphic-unfetch": "^2.0.0",
     "json-loader": "^0.5.4",

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -3,6 +3,8 @@ import fs from 'fs.promised';
 import copy from 'recursive-copy';
 import mkdirp from 'mkdirp';
 import ora from 'ora';
+import chalk from 'chalk';
+import inquirer from 'inquirer';
 import promisify from 'es6-promisify';
 import spawn from 'cross-spawn-promise';
 import path from 'path';
@@ -85,8 +87,25 @@ export default asyncCommand({
 		}
 		catch (err) {}
 
+		if (exists && argv.force) {
+			const question = {
+        type: 'confirm',
+        name: 'enableForce',
+        message: `You are using '--force'. Do you wish to continue?`,
+        default: true,
+      };
+
+			let forceInit = await inquirer.prompt(question);
+
+			if (forceInit.enableForce) {
+				process.stdout.write('Initializing project in the current directory...\n');
+			} else {
+				throw Error('Cannot initialize the project in the current directory');
+			}
+		}
+
 		if (exists && !argv.force) {
-			throw Error('Directory already exists.');
+			throw Error('Cannot intialize in the current directory, please specify a different destination.');
 		}
 
 		let spinner = ora({

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -95,18 +95,18 @@ export default asyncCommand({
 				default: false,
 			};
 
-			let forceInit = await inquirer.prompt(question);
+			let { enableForce } = await inquirer.prompt(question);
 
-			if (forceInit.enableForce) {
+			if (enableForce) {
 				process.stdout.write('Initializing project in the current directory...\n');
 			} else {
-				process.stdout.write(`${chalk.red('Error:')} Cannot initialize in the current directory`);
+				process.stderr.write(chalk.red('Error: Cannot initialize in the current directory\n'));
 				process.exit(1);
 			}
 		}
 
 		if (exists && !argv.force) {
-			process.stdout.write(`${chalk.red('Error:')} Cannot initialize in the current directory, please specify a different destination`);
+			process.stderr.write(chalk.red('Error: Cannot initialize in the current directory, please specify a different destination\n'));
 			process.exit(1);
 		}
 

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -3,7 +3,6 @@ import fs from 'fs.promised';
 import copy from 'recursive-copy';
 import mkdirp from 'mkdirp';
 import ora from 'ora';
-import chalk from 'chalk';
 import inquirer from 'inquirer';
 import promisify from 'es6-promisify';
 import spawn from 'cross-spawn-promise';

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -89,11 +89,11 @@ export default asyncCommand({
 
 		if (exists && argv.force) {
 			const question = {
-        type: 'confirm',
-        name: 'enableForce',
-        message: `You are using '--force'. Do you wish to continue?`,
-        default: false,
-      };
+				type: 'confirm',
+				name: 'enableForce',
+				message: `You are using '--force'. Do you wish to continue?`,
+				default: false,
+			};
 
 			let forceInit = await inquirer.prompt(question);
 

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -3,6 +3,7 @@ import fs from 'fs.promised';
 import copy from 'recursive-copy';
 import mkdirp from 'mkdirp';
 import ora from 'ora';
+import chalk from 'chalk';
 import inquirer from 'inquirer';
 import promisify from 'es6-promisify';
 import spawn from 'cross-spawn-promise';
@@ -91,7 +92,7 @@ export default asyncCommand({
         type: 'confirm',
         name: 'enableForce',
         message: `You are using '--force'. Do you wish to continue?`,
-        default: true,
+        default: false,
       };
 
 			let forceInit = await inquirer.prompt(question);
@@ -99,12 +100,14 @@ export default asyncCommand({
 			if (forceInit.enableForce) {
 				process.stdout.write('Initializing project in the current directory...\n');
 			} else {
-				throw Error('Cannot initialize the project in the current directory');
+				process.stdout.write(`${chalk.red('Error:')} Cannot initialize in the current directory`);
+				process.exit(1);
 			}
 		}
 
 		if (exists && !argv.force) {
-			throw Error('Cannot intialize in the current directory, please specify a different destination.');
+			process.stdout.write(`${chalk.red('Error:')} Cannot initialize in the current directory, please specify a different destination`);
+			process.exit(1);
 		}
 
 		let spinner = ora({

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -29,6 +29,10 @@ export default asyncCommand({
 			description: 'Directory to create the app within',
 			defaultDescription: '<name>'
 		},
+		force: {
+			description: 'Force option to create the directory for the new app',
+			default: false
+		},
 		type: {
 			description: 'A project template to start from',
 			choices: [
@@ -81,7 +85,7 @@ export default asyncCommand({
 		}
 		catch (err) {}
 
-		if (exists) {
+		if (exists && !argv.force) {
 			throw Error('Directory already exists.');
 		}
 
@@ -90,7 +94,9 @@ export default asyncCommand({
 			color: 'magenta'
 		}).start();
 
-		await promisify(mkdirp)(target);
+		if (!exists) {
+			await promisify(mkdirp)(target);
+		}
 
 		await copy(
 			path.resolve(__dirname, '../..', template),


### PR DESCRIPTION
Fixes #110 
by specifying --force this will allow you to create project in current directory.

@developit just curious, the discussion emphasize upon the usage of `--force`?
What if we do it without this? Whats the harm with that?