### PR TITLE
feat: Less verbose error output

### DIFF
--- a/src/lib/webpack/run-webpack.js
+++ b/src/lib/webpack/run-webpack.js
@@ -26,23 +26,21 @@ const devBuild = async (env, onprogress) => {
 
 	let compiler = webpack(config);
 	return await new Promise((resolve, reject) => {
-		let first = true;
+
 		compiler.plugin('done', stats => {
-			if (first) {
-				first = false;
-				let devServer = config.devServer;
+			let devServer = config.devServer;
 
-				let protocol = devServer.https ? 'https' : 'http';
-				let host = process.env.HOST || devServer.host || 'localhost';
+			let protocol = devServer.https ? 'https' : 'http';
+			let host = process.env.HOST || devServer.host || 'localhost';
 
-				let serverAddr = `${protocol}://${host}:${chalk.bold(port)}`;
-				let localIpAddr = `${protocol}://${ip.address()}:${chalk.bold(port)}`;
+			let serverAddr = `${protocol}://${host}:${chalk.bold(port)}`;
+			let localIpAddr = `${protocol}://${ip.address()}:${chalk.bold(port)}`;
 
-				if (stats.hasErrors()) {
-					process.stdout.write(chalk.red('\Build failed!\n\n'));
-				} else {
-					process.stdout.write(chalk.green('\nCompiled successfully!\n\n'));
-				}
+			clearConsole();
+			if (stats.hasErrors()) {
+				process.stdout.write(chalk.red('\Build failed!\n\n'));
+			} else {
+				process.stdout.write(chalk.green('\nCompiled successfully!\n\n'));
 
 				if (userPort !== port) {
 					process.stdout.write(`Port ${chalk.bold(userPort)} is in use, using ${chalk.bold(port)} instead\n\n`);
@@ -51,6 +49,7 @@ const devBuild = async (env, onprogress) => {
 				process.stdout.write(`${chalk.bold('Local:')}            ${serverAddr}\n`);
 				process.stdout.write(`${chalk.bold('On Your Network:')}  ${localIpAddr}\n`);
 			}
+
 			if (onprogress) onprogress(stats);
 		});
 		compiler.plugin('failed', reject);
@@ -126,6 +125,12 @@ export function writeJsonStats(stats) {
 			process.stdout.write('- https://webpack.github.io/analyse/\n');
 		});
 }
+
+const clearConsole = () => {
+	process.stdout.write(
+		process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H'
+	);
+};
 
 const stripBabelLoaderFromModuleNames = m => {
 	const keysToNormalize = ['identifier', 'name', 'module', 'moduleName', 'moduleIdentifier'];


### PR DESCRIPTION
+1000 to DX

`preact build` before:
<img width="624" alt="build-old" src="https://user-images.githubusercontent.com/7580355/27984247-1dc38508-63d1-11e7-93b0-0d14b25d2a6a.png">

`preact build` after:
<img width="1116" alt="build-new" src="https://user-images.githubusercontent.com/7580355/27984248-253328de-63d1-11e7-915d-36b24c3598ea.png">

`preact watch` before:
<img width="909" alt="watch-old" src="https://user-images.githubusercontent.com/7580355/27984250-30870e30-63d1-11e7-8162-14d2bcdcb84d.png">

`preact watch` after:
<img width="1124" alt="watch-new" src="https://user-images.githubusercontent.com/7580355/27984251-37dae4d6-63d1-11e7-88fe-66a94e5a1204.png">

Changes:
- `stats.toJSON()` accepts `options` which could be 'errors-only' (like in `webpack.config.js`)
- rewrote `babel-loader` query stripping (placed by `async-component-loader`) to be more precise & maintanable (= renamed it 😆 )