### PR TITLE
Update readme to reflect actual build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ $ preact build
   --src             Entry file (index.js).                        [default: "src"]
   --dest            Directory root for output.                    [default: "build"]
   --production, -p  Create a minified production build.           [default: true]
-  --less, -l        Build and compile LESS files.                 [default: false]
-  --sass, -s        Build and compile SASS files.                 [default: false]
   --prerender       Pre-render static app content.                [default: true]
   --prerenderUrls   Path to pre-render routes configuration.      [default "prerender-urls.json"]
   --template        Path to template file.


### PR DESCRIPTION
In the Readme we say we can use the --less and --sass flag but it doesn't exist like you can see:

<img width="588" alt="screenshot 2017-07-13 09 37 15" src="https://user-images.githubusercontent.com/1051509/28157731-525b1fec-67af-11e7-957c-8a28cca490a6.png">
