### PR TITLE
rebuild application when a new package is added

### DIFF
--- a/src/lib/webpack/run-webpack.js
+++ b/src/lib/webpack/run-webpack.js
@@ -27,6 +27,18 @@ const devBuild = async (env, onprogress) => {
 	let compiler = webpack(config);
 	return await new Promise((resolve, reject) => {
 
+		compiler.plugin('emit', (compilation, callback) => {
+			var missingDeps = compilation.missingDependencies;
+			var nodeModulesPath = path.resolve(__dirname, '../../../node_modules');
+
+			if (missingDeps.some(file => file.indexOf(nodeModulesPath) !== -1)) {
+				// ...tell webpack to watch node_modules recursively until they appear.
+				compilation.contextDependencies.push(nodeModulesPath);
+			}
+
+			callback();
+		});
+
 		compiler.plugin('done', stats => {
 			let devServer = config.devServer;
 


### PR DESCRIPTION
With this PR we can simply add a new package to the application and can use the package right away without restarting the local server.

Took the idea from Facebook's CRA.

Fixes - #208 