### PR TITLE
Revert to compiling webpack configs in sequence

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "get-port": "^3.1.0",
     "html-webpack-exclude-assets-plugin": "0.0.5",
     "html-webpack-plugin": "^2.28.0",
-    "html-webpack-wait-for-assets-plugin": "^1.0.0",
     "inquirer": "^3.2.0",
     "ip": "^1.1.5",
     "isomorphic-unfetch": "^2.0.0",

--- a/src/lib/webpack/run-webpack.js
+++ b/src/lib/webpack/run-webpack.js
@@ -72,31 +72,36 @@ const devBuild = async (env, onprogress) => {
 };
 
 const prodBuild = async (env) => {
-	let compiler, client = clientConfig(env);
+	let config = clientConfig(env);
 
-	await transformConfig(env, client);
+	await transformConfig(env, config);
+	let serverCompiler, clientCompiler = webpack(config);
 
 	if (env.prerender) {
 		let ssrConfig = serverConfig(env);
 		await transformConfig(env, ssrConfig, true);
-		compiler = webpack([client, ssrConfig]);
-	} else {
-		compiler = webpack(client);
+		serverCompiler = webpack(ssrConfig);
+		await runCompiler(serverCompiler);
 	}
 
-	return await new Promise((resolve, reject) => {
-		compiler.run((err, stats) => {
-			if (err || stats.hasErrors()) {
-				showStats(stats);
-				reject(chalk.red('Build failed!'));
-			}
-			else {
-				// Timeout for plugins that work on `after-emit` event of webpack
-				setTimeout(()=>	resolve(stats), 20);
-			}
-		});
-	});
+	let stats = await runCompiler(clientCompiler);
+
+	// Timeout for plugins that work on `after-emit` event of webpack
+	await new Promise(r => setTimeout(()=>	r(), 20));
+
+	return stats;
 };
+
+const runCompiler = compiler => new Promise((resolve, reject) => {
+	compiler.run((err, stats) => {
+		if (err || stats.hasErrors()) {
+			showStats(stats);
+			reject(chalk.red('Build failed!'));
+		}
+
+		resolve(stats);
+	});
+});
 
 export function showStats(stats) {
 	let info = stats.toJson("errors-only");

--- a/src/lib/webpack/webpack-client-config.js
+++ b/src/lib/webpack/webpack-client-config.js
@@ -13,7 +13,6 @@ import {
 import devServer from '@webpack-blocks/dev-server2';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import HtmlWebpackExcludeAssetsPlugin from 'html-webpack-exclude-assets-plugin';
-import HtmlWebpackWaitForAssetsPlugin from 'html-webpack-wait-for-assets-plugin';
 import ScriptExtHtmlWebpackPlugin from 'script-ext-html-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import SWPrecacheWebpackPlugin from 'sw-precache-webpack-plugin';
@@ -233,9 +232,6 @@ const htmlPlugin = (config, src) => {
 			new ScriptExtHtmlWebpackPlugin({
 				// inline: 'bundle.js',
 				defaultAttribute: 'defer'
-			}),
-			new HtmlWebpackWaitForAssetsPlugin({
-				assets: [resolve(config.dest, './ssr-build/ssr-bundle.js')]
 			})
 		]));
 };


### PR DESCRIPTION
This turn offs multi-compiler mode in webpack as it seems unreliable.

From [docs](https://webpack.js.org/api/node/#webpack-) :
```
webpack will not run the multiple configurations in parallel. Each configuration is only processed after the previous one has finished processing. To have webpack process them in parallel, you can use a third-party solution like parallel-webpack.
```

Which is untrue (we've had ```webpack([ssrConfig, clientConfig])``` previously and `clientConfig` was processed before `ssrConfig` - now it seems random)