### PR TITLE
Improve .css glob

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -198,7 +198,13 @@ export default asyncCommand({
 			if (argv.sass) extension = '.scss';
 			if (argv.stylus) extension = '.styl';
 
-			const cssFiles = await promisify(glob)(`${target}/**/*.css`, { ignore: `${target}/build/**` });
+			const cssFiles = await promisify(glob)(`${target}/**/*.css`, {
+				ignore: [
+					`${target}/build/**`,
+					`${target}/node_modules/**`
+				]
+			});
+
 			const changeExtension = fileName => fs.rename(fileName, fileName.replace(/.css$/, extension));
 
 			await Promise.all(cssFiles.map(changeExtension));


### PR DESCRIPTION
This will prevent searching `node_modules` folder for `.css` files during `preact create` if any preprocessor option is given.

* target/build
* target/node_modules

Added `target/node_modules` to glob ignore.