### PR TITLE
yarn start error fix

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -219,13 +219,13 @@ export default asyncCommand({
 			  \u001b[32mcd ${path.relative(process.cwd(), target)}\u001b[39m
 
 			To start a development live-reload server:
-			  \u001b[32m${argv.yarn === true ? 'yarnpkg start' : 'npm start'}\u001b[39m
+			  \u001b[32m${argv.yarn === true ? 'yarn start' : 'npm start'}\u001b[39m
 
 			To create a production build (in ./build):
-			  \u001b[32m${argv.yarn === true ? 'yarnpkg build' : 'npm run build'}\u001b[39m
+			  \u001b[32m${argv.yarn === true ? 'yarn build' : 'npm run build'}\u001b[39m
 
 			To start a production HTTP/2 server:
-			  \u001b[32m${argv.yarn === true ? 'yarnpkg serve' : 'npm run serve'}\u001b[39m
+			  \u001b[32m${argv.yarn === true ? 'yarn serve' : 'npm run serve'}\u001b[39m
 		`) + '\n';
 	}
 });

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -45,7 +45,7 @@ const pkgScripts = async (yarn, pkg) => {
 	if (isYarnAvailable && yarn) {
 		return {
 			...(pkg.scripts || {}),
-			start: 'if-env NODE_ENV=production && yarnpkg -s serve || yarnpkg -s dev',
+			start: 'if-env NODE_ENV=production && yarn run -s serve || yarn run -s dev',
 			build: 'preact build',
 			serve: 'preact build && preact serve',
 			dev: 'preact watch',


### PR DESCRIPTION
when running custom scripts we have use use `yarn run -s serve`, which I forgot when I was adding yarn support.

Fixes: #245 