### PR TITLE
Only remove prop types in a production build.

### DIFF
--- a/src/lib/babel-config.js
+++ b/src/lib/babel-config.js
@@ -1,30 +1,34 @@
-export default (env, options={}) => ({
-	babelrc: false,
-	presets: [
-		[require.resolve('babel-preset-env'), {
-			loose: true,
-			uglify: true,
-			modules: options.modules || false,
-			targets: {
-				browsers: options.browsers
-			},
-			exclude: [
-				'transform-regenerator',
-				'transform-es2015-typeof-symbol'
-			]
-		}],
-		require.resolve('babel-preset-stage-1')
-	],
-	plugins: [
-		require.resolve('babel-plugin-transform-object-assign'),
-		require.resolve('babel-plugin-transform-decorators-legacy'),
-		require.resolve('babel-plugin-transform-react-constant-elements'),
-		require.resolve('babel-plugin-transform-react-remove-prop-types'),
-		[require.resolve('babel-plugin-transform-react-jsx'), { pragma: 'h' }],
-		[require.resolve('babel-plugin-jsx-pragmatic'), {
-			module: 'preact',
-			export: 'h',
-			import: 'h'
-		}]
-	]
-});
+export default (env, options={}) => {
+	const isProd = env && env.production;
+
+	return {
+		babelrc: false,
+		presets: [
+			[require.resolve('babel-preset-env'), {
+				loose: true,
+				uglify: true,
+				modules: options.modules || false,
+				targets: {
+					browsers: options.browsers
+				},
+				exclude: [
+					'transform-regenerator',
+					'transform-es2015-typeof-symbol'
+				]
+			}],
+			require.resolve('babel-preset-stage-1')
+		],
+		plugins: [
+			require.resolve('babel-plugin-transform-object-assign'),
+			require.resolve('babel-plugin-transform-decorators-legacy'),
+			require.resolve('babel-plugin-transform-react-constant-elements'),
+			isProd ? require.resolve('babel-plugin-transform-react-remove-prop-types') : null,
+			[require.resolve('babel-plugin-transform-react-jsx'), { pragma: 'h' }],
+			[require.resolve('babel-plugin-jsx-pragmatic'), {
+				module: 'preact',
+				export: 'h',
+				import: 'h'
+			}]
+		].filter(Boolean)
+	};
+};


### PR DESCRIPTION
Disable 'babel-plugin-transform-react-remove-prop-types'
plugin during a development build. Some libraries
expect prop types to be available during a development
build.

Semantic UI React uses prop types during development
for validation. [Issue 1869](https://github.com/Semantic-Org/Semantic-UI-React/issues/1869) has some additional context.