### PR TITLE
Look for process.env.HTTPS for devServer

### DIFF
--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -43,9 +43,7 @@ export default asyncCommand({
 	async handler(argv) {
 		argv.production = false;
 
-		if (process.env.HTTPS) argv.https = true;
-
-		if (argv.https) {
+		if (argv.https || process.env.HTTPS) {
 			let ssl = await getSslCert();
 			if (!ssl) {
 				ssl = true;

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -43,6 +43,8 @@ export default asyncCommand({
 	async handler(argv) {
 		argv.production = false;
 
+		if (process.env.HTTPS) argv.https = true;
+
 		if (argv.https) {
 			let ssl = await getSslCert();
 			if (!ssl) {

--- a/src/lib/webpack/run-webpack.js
+++ b/src/lib/webpack/run-webpack.js
@@ -41,7 +41,7 @@ const devBuild = async (env, onprogress) => {
 
 		compiler.plugin('done', stats => {
 			let devServer = config.devServer;
-			let protocol = devServer.https ? 'https' : 'http';
+			let protocol = (process.env.HTTPS || devServer.https) ? 'https' : 'http';
 			let host = process.env.HOST || devServer.host || 'localhost';
 
 			let serverAddr = `${protocol}://${host === '0.0.0.0' ? 'localhost' : host}:${chalk.bold(port)}`;


### PR DESCRIPTION
Now you can do `HTTPS=true npm start` for starting the development server using `https`.

We can avoid that serious regression of flags in
```
npm start -- -- --https
```

Fixes #242 