### PR TITLE
fix: check node version

### DIFF
--- a/check.js
+++ b/check.js
@@ -11,7 +11,7 @@ module.exports = function () {
 
 	const errorMessage = colors.yellow(`
 
-		⚠️ preact-cli requires at least node@${minimum}!
+		⚠️  preact-cli requires at least node@${minimum}!
 		You have node@${version}
 
 	`);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "pretest": "npm run -s build && rimraf ./tests/output",
     "test": "jest",
     "posttest": "rimraf ./tests/output",
-    "postinstall": "node check.js",
+    "postinstall": "node -p 'require(\"./check.js\")()'",
     "test:build": "babel-node src build --cwd examples/root",
     "test:serve": "npm run -s test:build && babel-node src serve --port 3000 --cwd examples/root",
     "test:serve:config": "npm run -s test:build && babel-node src serve --server config --cwd examples/root",


### PR DESCRIPTION
Earlier we were just trying to do `node check.js` on `postinstall` script. This won't execute the function which we exported.

So, changed the postinstall script to `node -p 'require(\"./check.js\")()'`