### PR TITLE
Update yarn quickstart instructions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm run build
 preact create your-app-name --yarn
 
 # start a live-reload/HMR dev server:
-yarn watch
+yarn start
 
 # go to production:
 yarn build


### PR DESCRIPTION
The command to start a live-reload/HMR dev server should be `yarn start` instead of `yarn watch`.

Related to this PR:
https://github.com/developit/preact-cli/pull/246/files