### PR TITLE
watch on whole 'src' folder instead of 'components' & 'routes'

### DIFF
--- a/src/lib/webpack/webpack-base-config.js
+++ b/src/lib/webpack/webpack-base-config.js
@@ -176,8 +176,7 @@ export default (env) => {
 					{
 						test: /\.(css|less|s[ac]ss|styl)$/,
 						include: [
-							src('components'),
-							src('routes')
+							src('./')
 						],
 						loader: ExtractTextPlugin.extract({
 							fallback: 'style-loader',
@@ -190,8 +189,7 @@ export default (env) => {
 					{
 						test: /\.(css|less|s[ac]ss|styl)$/,
 						exclude: [
-							src('components'),
-							src('routes')
+							src('./')
 						],
 						loader: ExtractTextPlugin.extract({
 							fallback: 'style-loader',


### PR DESCRIPTION
Fixes #309 

Instead of watching over `components` & `routes` folder in `src`, it will look up for all the folders.