### PR TITLE
Use Bluebird for Promisification

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "css-modules-require-hook": "^4.0.6",
     "devcert-san": "^0.3.3",
     "ejs-loader": "^0.3.0",
-    "es6-promisify": "^5.0.0",
     "extract-text-webpack-plugin": "^2.1.2",
     "file-loader": "^0.11.1",
     "fs.promised": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "babel-preset-env": "^1.3.3",
     "babel-preset-stage-1": "^6.24.1",
     "babel-register": "^6.24.1",
+    "bluebird": "^3.5.0",
     "chalk": "^2.1.0",
     "copy-webpack-plugin": "^4.0.1",
     "cross-spawn-promise": "^0.10.1",

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -1,5 +1,4 @@
 import { resolve } from 'path';
-import promisify from 'es6-promisify';
 import rimraf from 'rimraf';
 import asyncCommand from '../lib/async-command';
 import runWebpack, { showStats, writeJsonStats } from '../lib/webpack/run-webpack';
@@ -51,7 +50,7 @@ export default asyncCommand({
 	async handler(argv) {
 		if (argv.clean) {
 			let dest = resolve(argv.cwd || process.cwd(), argv.dest || 'build');
-			await promisify(rimraf)(dest);
+			await Promise.promisify(rimraf)(dest);
 		}
 
 		let stats = await runWebpack(false, argv);

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -6,7 +6,6 @@ import mkdirp from 'mkdirp';
 import ora from 'ora';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-import promisify from 'es6-promisify';
 import path from 'path';
 import { install, initialize, pkgScripts, initGit, trimLeft } from './../lib/setup';
 
@@ -120,7 +119,7 @@ export default asyncCommand({
 		}).start();
 
 		if (!exists) {
-			await promisify(mkdirp)(target);
+			await Promise.promisify(mkdirp)(target);
 		}
 
 		await copy(
@@ -196,7 +195,7 @@ export default asyncCommand({
 			if (argv.sass) extension = '.scss';
 			if (argv.stylus) extension = '.styl';
 
-			const cssFiles = await promisify(glob)(`${target}/**/*.css`, {
+			const cssFiles = await Promise.promisify(glob)(`${target}/**/*.css`, {
 				ignore: [
 					`${target}/build/**`,
 					`${target}/node_modules/**`

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -6,7 +6,6 @@ import mkdirp from 'mkdirp';
 import ora from 'ora';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-import promisify from 'es6-promisify';
 import path from 'path';
 import { install, initialize, pkgScripts, initGit, trimLeft } from './../lib/setup';
 
@@ -144,7 +143,7 @@ export default asyncCommand({
 		}).start();
 
 		if (!exists) {
-			await promisify(mkdirp)(target);
+			await Promise.promisify(mkdirp)(target);
 		}
 
 		await copy(
@@ -220,7 +219,7 @@ export default asyncCommand({
 			if (response.style === 'sass') extension = '.scss';
 			if (response.style === 'stylus') extension = '.styl';
 
-			const cssFiles = await promisify(glob)(`${target}/**/*.css`, {
+			const cssFiles = await Promise.promisify(glob)(`${target}/**/*.css`, {
 				ignore: [
 					`${target}/build/**`,
 					`${target}/node_modules/**`

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import pkg from '../package.json';
 import logo from './lib/logo';
 import checkVersion from './../check';
 
-global.Promise = require('promise-polyfill');
+global.Promise = require('bluebird');
 
 checkVersion();
 

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -1,7 +1,6 @@
 import path from 'path';
 import which from 'which';
 import fs from 'fs.promised';
-import promisify from 'es6-promisify';
 import spawn from 'cross-spawn-promise';
 import { commandExists } from './shell';
 
@@ -74,7 +73,7 @@ const initGit = async (target) => {
 	let git;
 
 	try {
-		git = await promisify(which)('git');
+		git = await Promise.promisify(which)('git');
 	} catch (e) {
 		process.stderr.write('Could not find git in $PATH.\n');
 		process.stdout.write('Continuing without initializing version control...\n');

--- a/src/lib/shell.js
+++ b/src/lib/shell.js
@@ -1,9 +1,8 @@
-import promisify from 'es6-promisify';
 import which from 'which';
 
 const commandExists = async cmd => {
 	try {
-		await promisify(which)(cmd);
+		await Promise.promisify(which)(cmd);
 		return true;
 	} catch (e){
 		return false;

--- a/tests/lib/output.js
+++ b/tests/lib/output.js
@@ -1,8 +1,8 @@
 import { resolve } from 'path';
-import promisify from 'es6-promisify';
 import mkdirp from 'mkdirp';
 import uuid from 'uuid/v4';
 import ncp from 'ncp';
+import { promisify } from 'bluebird';
 import spawn from 'cross-spawn-promise';
 import { withLog } from './utils';
 import { shouldInstallDeps } from './tests-config';


### PR DESCRIPTION
We already had `Bluebird` installed via `html-webpack-plugin`, so no need to add an extra dependency.

***Benefits:***

- Remove 2 dependencies
- Use "built-in" promisification
- Performance boost (via `global.Promise = Bluebird`)