### PR TITLE
Enforce `template` directory

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -91,9 +91,8 @@ export default asyncCommand({
 		await gittar.extract(archive, target, {
 			strip: 2,
 			filter(path) {
-				// TODO: remove `/build/` ??
 				// TODO: read & respond to meta/hooks
-				return path.includes('/template/') && !path.includes('/build/');
+				return path.includes('/template/');
 			}
 		});
 

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -88,13 +88,18 @@ export default asyncCommand({
 		}).start();
 
 		// Extract files from `archive` to `target`
+		// TODO: read & respond to meta/hooks
+		let hasDir = false;
 		await gittar.extract(archive, target, {
 			strip: 2,
 			filter(path) {
-				// TODO: read & respond to meta/hooks
-				return path.includes('/template/');
+				return path.includes('/template/') && (hasDir = true);
 			}
 		});
+
+		if (!hasDir) {
+			return error(`No \`template\` directory found within ${ repo }!`, 1);
+		}
 
 		spinner.text = 'Parsing `package.json` file';
 


### PR DESCRIPTION
Also removes the restriction on `/build/` since we'll just accept everything within `/template/` -- this allows `/template/build/**` to be copied if the author has it.

---

_Closes #351_ 