### PR TITLE
Inject values into extracted Template files

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -100,15 +100,16 @@ export default asyncCommand({
 			strip: 2,
 			filter(path, obj) {
 				if (path.includes('/template/')) {
-					obj.on('end', _ => obj.type==='File' && keeps.push(obj.absolute));
+					obj.on('end', () => obj.type==='File' && keeps.push(obj.absolute));
 					return true;
 				}
 			}
 		});
 
 		if (keeps.length) {
-			// TODO: concat author-driven patterns
+			// eslint-disable-next-line
 			let dict = new Map();
+			// TODO: concat author-driven patterns
 			['name'].forEach(str => {
 				// if value is defined
 				if (argv[str] !== void 0) {


### PR DESCRIPTION
Admittedly a bit of a rough approach, but it sets the stage for proper author-driven experience later on (probably `2.1`)

* Chose the most popular syntax, as voted in #353

* Right now, only replaces the `{{ name }}` string
    * Ideally, author prompts' key-names are added to the list

---

_Closes #353_