### PR TITLE
Enable PostCSS SourceMaps

### DIFF
--- a/src/lib/webpack/webpack-base-config.js
+++ b/src/lib/webpack/webpack-base-config.js
@@ -142,6 +142,7 @@ export default function (env) {
 							{
 								loader: 'postcss-loader',
 								options: {
+									sourceMap: isProd,
 									plugins: [autoprefixer({ browsers })]
 								}
 							}
@@ -166,6 +167,7 @@ export default function (env) {
 							{
 								loader: 'postcss-loader',
 								options: {
+									sourceMap: isProd,
 									plugins: [autoprefixer({ browsers })]
 								}
 							}


### PR DESCRIPTION
The move to `postcss-loader@2.x` changed the `sourceMap` behavior.

In [`postcss-loader@1.x`](https://github.com/postcss/postcss-loader/tree/1.3.3), the maps from preceding loaders (eg, css, sass, less) would still be kept. But as @timarney pointed out, 2.0 changed that behavior. The `postcss-loader` now states:

> If a previous loader like e.g `sass-loader` is applied and its `sourceMap` option is set, but the sourceMap option in `postcss-loader` is omitted, previous source maps will be discarded by `postcss-loader` **entirely**.

_Closes #403_