### PR TITLE
exposing preact-cli babel configs as a preset

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -1,0 +1,36 @@
+var isProd = (process.env.BABEL_ENV || process.env.NODE_ENV) === "production";
+/**
+ * test env detection is used to default mode for
+ * preset-env modules to "commonjs" otherwise, testing framework
+ * will struggle
+ */
+var isTest = (process.env.BABEL_ENV || process.env.NODE_ENV) === "test";
+
+// default supported browser.
+var defaultBrowserList = ["> 1%", "last 2 versions", "IE >= 9"];
+
+// preact-cli babel configs
+var babelConfigs = require("./lib/lib/babel-config").default;
+
+/**
+ * preset as a function means allow users to override some options
+ * like env, modules for environment
+ */
+module.exports = function preactCli(ctx, userOptions = {}) {
+
+	// set default configs based on user environment
+  var presetOptions = {
+    env: isProd ? "production" : "development",
+    modules: isTest ? "commonjs" : false,
+    browsers: defaultBrowserList
+  };
+
+	// user specified options always the strongest
+	Object.keys(presetOptions).forEach(function(key) {
+    presetOptions[key] = userOptions[key] || presetOptions[key];
+	});
+
+	// yay! return the configs
+	return babelConfigs({ env: { production: presetOptions.env === "production" }},
+	{ modules: presetOptions.modules, browsers: presetOptions.browsers });
+};

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "files": [
     "lib",
     "examples",
-    "check.js"
+    "check.js",
+    "babel.js"
   ],
   "keywords": [
     "preact",


### PR DESCRIPTION
The motivation:

Except for writing tests, I never needed to have `.babelrc` in my project root when using preact-cli but testing framework is a key part of every project and now we have to maintain a .babelrc with a bunch of babel presests and plugins that might or might not be as optimized and tested as preact-cli internal one.

This PR:
will expose preact-cli babel configs as a preset.

Show us an example:

`.babelrc`
```
{
  "presets": ["preact-cli/babel"]
}
```
now, what about options? This PR at the moment supports all variables that preact-cli's babel might ask for or need. you can go with defaults or pass your own preset options as:
```
{
  "presets": [["preact-cli/babel"], { "env": "space", "modules": "false", "browsers":  ["> 100%", "last 200 versions", "IE >= 19"] }]
}
```

Yay!, you can run Jest in your preact-cli projects with 0 babel module in your `package.json` or any external scripts.

I'll do more testing tomorrow, reviews & ideas are welcome.