### PR TITLE
Allow PostCSS to `sourceMap` in Dev mode

### DIFF
--- a/src/lib/webpack/webpack-base-config.js
+++ b/src/lib/webpack/webpack-base-config.js
@@ -142,7 +142,7 @@ export default function (env) {
 							{
 								loader: 'postcss-loader',
 								options: {
-									sourceMap: isProd,
+									sourceMap: true,
 									plugins: [autoprefixer({ browsers })]
 								}
 							}
@@ -167,7 +167,7 @@ export default function (env) {
 							{
 								loader: 'postcss-loader',
 								options: {
-									sourceMap: isProd,
+									sourceMap: true,
 									plugins: [autoprefixer({ browsers })]
 								}
 							}


### PR DESCRIPTION
Previous PR (#404) enabled `sourceMap`s for production builds _only_.  Derp. This enables mapping during development.

_Closes #403 ... again_