### PR TITLE
hmr fix

### DIFF
--- a/src/lib/webpack/webpack-client-config.js
+++ b/src/lib/webpack/webpack-client-config.js
@@ -10,14 +10,19 @@ import PushManifestPlugin from './push-manifest';
 import baseConfig from './webpack-base-config';
 
 function clientConfig(env) {
-	const { isProd, source, src } = env;
+	const { isProd, source, src /*, port? */ } = env;
+
+	let entry = {
+		bundle: resolve(__dirname, './../entry'),
+		polyfills: resolve(__dirname, './polyfills')
+	};
+
+	if (!isProd) {
+		entry['hmr'] = `webpack-dev-server/client?http://localhost:${process.env.PORT || env.port || 8080}`;
+	}
 
 	return {
-		entry: {
-			bundle: resolve(__dirname, './../entry'),
-			polyfills: resolve(__dirname, './polyfills')
-		},
-
+		entry: entry,
 		output: {
 			path: env.dest,
 			publicPath: '/',
@@ -158,7 +163,7 @@ function isDev(config) {
 
 		devServer: {
 			inline: true,
-			hot: true,
+			/* setting hot:true will fuck up the HMR -- so DON'T! */
 			compress: true,
 			publicPath: '/',
 			contentBase: src,


### PR DESCRIPTION
I have a little preact-cli project I work with on weekends.

Today HMR stopped working and I am able to get it to work back via this fix.

dev-server was not emitting socket-js with the dev bundle and seems like the combo of Webpack HMR plugin + `hot:true` in dev-server options is not working.

This fix will ensure in Dev mode, the required socket stuff are committed to `hmr` bundle and the reload happens.

is there better ideas? happy to discuss.