### PR TITLE
Allow any/all Prerender Values

### DIFF
--- a/src/lib/webpack/render-html-plugin.js
+++ b/src/lib/webpack/render-html-plugin.js
@@ -9,28 +9,31 @@ import prerender from './prerender';
 export default function (config) {
 	const { cwd, dest, isProd, src } = config;
 
-	const htmlWebpackConfig = ({ url, title }) => ({
-		filename: resolve(dest, url.substring(1), 'index.html'),
-		template: `!!ejs-loader!${config.template || resolve(__dirname, '../../resources/template.html')}`,
-		minify: isProd && {
-			collapseWhitespace: true,
-			removeScriptTypeAttributes: true,
-			removeRedundantAttributes: true,
-			removeStyleLinkTypeAttributes: true,
-			removeComments: true
-		},
-		favicon: existsSync(resolve(src, 'assets/favicon.ico')) ? 'assets/favicon.ico' : resolve(__dirname, '../../resources/favicon.ico'),
-		manifest: config.manifest,
-		inject: true,
-		compile: true,
-		preload: config.preload===true,
-		title: title || config.title || config.manifest.name || config.manifest.short_name || (config.pkg.name || '').replace(/^@[a-z]\//, '') || 'Preact App',
-		excludeAssets: [/(bundle|polyfills)(\..*)?\.js$/],
-		config,
-		ssr(params) {
-			return config.prerender ? prerender({ cwd, dest, src }, { ...params, url }) : '';
-		}
-	});
+	const htmlWebpackConfig = values => {
+		let { url, title } = values;
+		return Object.assign(values, {
+			filename: resolve(dest, url.substring(1), 'index.html'),
+			template: `!!ejs-loader!${config.template || resolve(__dirname, '../../resources/template.html')}`,
+			minify: isProd && {
+				collapseWhitespace: true,
+				removeScriptTypeAttributes: true,
+				removeRedundantAttributes: true,
+				removeStyleLinkTypeAttributes: true,
+				removeComments: true
+			},
+			favicon: existsSync(resolve(src, 'assets/favicon.ico')) ? 'assets/favicon.ico' : resolve(__dirname, '../../resources/favicon.ico'),
+			manifest: config.manifest,
+			inject: true,
+			compile: true,
+			preload: config.preload===true,
+			title: title || config.title || config.manifest.name || config.manifest.short_name || (config.pkg.name || '').replace(/^@[a-z]\//, '') || 'Preact App',
+			excludeAssets: [/(bundle|polyfills)(\..*)?\.js$/],
+			config,
+			ssr(params) {
+				return config.prerender ? prerender({ cwd, dest, src }, { ...params, url }) : '';
+			}
+		});
+	};
 
 	const pages = readJson(resolve(cwd, config.prerenderUrls || '')) || [{ url: '/' }];
 


### PR DESCRIPTION
Right now, we only allow for `url` and `title` values to be defined inside a prerender config file:

```js
// prerender-urls.json
[{
  "url": "/",
  "title": "Homepage"
}, {
  "url": "/route/random"
}]
```

This change allows the developer to pass **anything they want** inside the file. For example, descriptions, keywords, Google Analytics tracking IDs, etc.

It's meant to work alongside a [custom template file](https://github.com/developit/preact-cli#template) so that these values can be looked up & printed at `build` time.

```js
// prerender-urls.json
[{
  "url": "/",
  "title": "Home",
  "description": "Welcome to my website!"
}, {
  "url": "/about",
  "title": "About",
  "keywords": "mission statement, about us, foobar",
  "description": "Read about our mission!!"
}]
```

Merging this brings us 1 step closer to serving as a static-site generator, of sorts. 🎉 