### PR TITLE
Fix webpack config not matching win32 paths

### DIFF
--- a/src/lib/webpack/webpack-client-config.js
+++ b/src/lib/webpack/webpack-client-config.js
@@ -56,8 +56,8 @@ function clientConfig(env) {
 					options: {
 						name(filename) {
 							filename = normalizePath(filename);
-							if (!filename.includes('/routes/')) return false;
 							let relative = filename.replace(normalizePath(src), '');
+							if (!relative.includes('/routes/')) return false;
 							return 'route-' + cleanFilename(relative);
 						},
 						formatName(filename) {

--- a/src/lib/webpack/webpack-client-config.js
+++ b/src/lib/webpack/webpack-client-config.js
@@ -8,6 +8,9 @@ import SWPrecacheWebpackPlugin from 'sw-precache-webpack-plugin';
 import RenderHTMLPlugin from './render-html-plugin';
 import PushManifestPlugin from './push-manifest';
 import baseConfig from './webpack-base-config';
+import { normalizePath } from '../../util';
+
+const cleanFilename = name => name.replace(/(^\/(routes|components\/(routes|async))\/|(\/index)?\.js$)/g, '');
 
 function clientConfig(env) {
 	const { isProd, source, src /*, port? */ } = env;
@@ -52,15 +55,15 @@ function clientConfig(env) {
 					loader: resolve(__dirname, './async-component-loader'),
 					options: {
 						name(filename) {
-							let relative = filename.replace(src, '');
-							let isRoute = filename.indexOf('/routes/') >= 0;
-
-							return isRoute ? 'route-' + relative.replace(/(^\/(routes|components\/(routes|async))\/|(\/index)?\.js$)/g, '') : false;
+							filename = normalizePath(filename);
+							if (!filename.includes('/routes/')) return false;
+							let relative = filename.replace(normalizePath(src), '');
+							return 'route-' + cleanFilename(relative);
 						},
 						formatName(filename) {
-							let relative = filename.replace(source('.'), '');
-							// strip out context dir & any file/ext suffix
-							return relative.replace(/(^\/(routes|components\/(routes|async))\/|(\/index)?\.js$)/g, '');
+							filename = normalizePath(filename);
+							let relative = filename.replace(normalizePath(source('.')), '');
+							return cleanFilename(relative);
 						}
 					}
 				}

--- a/src/util.js
+++ b/src/util.js
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import { statSync, existsSync } from 'fs';
 import logSymbols from 'log-symbols';
 import which from 'which';
+import { normalize } from 'path';
 
 export function isDir(str) {
 	return existsSync(str) && statSync(str).isDirectory();
@@ -28,4 +29,8 @@ export function warn(text, code) {
 export function error(text, code) {
 	process.stderr.write(logSymbols.error + chalk.red(' ERROR ') + text + '\n');
 	code && process.exit(code);
+}
+
+export function normalizePath(path) {
+	return normalize(path).replace(/\\/g, '/');
 }


### PR DESCRIPTION
Fixes #453 

AFAIK, this issue only occurred in this place, other webpack configs don't use unescaped paths. Nevertheless, I put the `normalizePath` function into `util.js` in case it has to be reused elsewhere in the future.