### PR TITLE
[FIX] Non-Unique Filename Hashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
     "update-notifier": "^2.3.0",
     "url-loader": "^0.5.8",
     "webpack": "^3.7.0",
-    "webpack-chunk-hash": "^0.4.0",
     "webpack-dev-server": "^2.9.0",
     "webpack-merge": "^4.1.0",
     "webpack-plugin-replace": "^1.1.1",

--- a/src/lib/webpack/webpack-base-config.js
+++ b/src/lib/webpack/webpack-base-config.js
@@ -5,7 +5,6 @@ import autoprefixer from 'autoprefixer';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import ProgressBarPlugin from 'progress-bar-webpack-plugin';
 import ReplacePlugin from 'webpack-plugin-replace';
-import WebpackChunkHash from 'webpack-chunk-hash';
 import requireRelative from 'require-relative';
 import createBabelConfig from '../babel-config';
 
@@ -228,7 +227,6 @@ export default function (env) {
 			new webpack.HashedModuleIdsPlugin(),
 			new webpack.LoaderOptionsPlugin({ minimize:true }),
 			new webpack.optimize.ModuleConcatenationPlugin(),
-			new WebpackChunkHash(),
 
 			// strip out babel-helper invariant checks
 			new ReplacePlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7464,10 +7464,6 @@ webidl-conversions@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
-webpack-chunk-hash@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/webpack-chunk-hash/-/webpack-chunk-hash-0.4.0.tgz#6b40c3070fbc9ff0cfe0fe781c7174af6c7c16a4"
-
 webpack-dev-middleware@^1.11.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz#d34efefb2edda7e1d3b5dbe07289513219651709"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixes #459 

**Did you add tests for your changes?**

N/A

**Summary**

Apparently, since October 2017, an underlying dependency has had an incompatibility with Webpack's `ModuleConcatenationPlugin`. Because of this, **all files and chunks** were producing the same `[hash]` and `[chunkhash]` values.

> Before removing, I tried adjusting the `output` patterns, but that didn't change anything.

Luckily, it seems as though we weren't actually using this plugin in the way it was intended, so simply removing it worked. 

We're now relying on Webpack's own hashing algorithm, which is probably a safe(r) bet since that's one of its first-class priorities.

---

@developit This will have to go out ASAP since everyone is producing repetitive builds. I suspect this is also playing a role in the SW issues.