### PR TITLE
Re-add dynamic import in client Babel config

### DIFF
--- a/src/lib/babel-config.js
+++ b/src/lib/babel-config.js
@@ -18,6 +18,7 @@ export default (env, options={}) => {
 			}]
 		],
 		plugins: [
+			require.resolve('babel-plugin-syntax-dynamic-import'),
 			require.resolve('babel-plugin-transform-object-assign'),
 			require.resolve('babel-plugin-transform-class-properties'),
 			require.resolve('babel-plugin-transform-export-extensions'),


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Summary**

#444 replaced the stage-1 preset with plugins, but syntax-dynamic-import was left out of the client babel config (it was correctly included in the cli config).

This is the error: 
```
Module build failed: SyntaxError: {file}.js: Unexpected token (18:8)
> 18 |   await import('firebase/firestore');
```

**Other information**
Node 8.9.0, npm 5.6.0, CLI 2.1.1, Windows 10 x64