### PR TITLE
Fix `Async` component warning when used with `preact/debug`

### DIFF
--- a/src/components/async.js
+++ b/src/components/async.js
@@ -11,6 +11,6 @@ export default function(load) {
 	}
 	Async.prototype = new Component;
 	Async.prototype.constructor = Async;
-	Async.prototype.render = (props, state) => h(state.child, props);
+	Async.prototype.render = (props, state) => state.child ? h(state.child, props) : null;
 	return Async;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No

**Summary**
Fixes #456:
> When using `preact/debug` as recommmended in the [Preact readme](https://github.com/developit/preact#debug-mode), async routes cause the following warning to appear in the browser console:
>
> ```
> Undefined component passed to preact.h()
> <undefined path="/" url="/" matches="[object Object]" /> debug.js:17
> ```
>
> The routes still work perfectly fine, but the warning is misleading and confusing.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Node version 8.9.1
npm version 5.6.0
Windows 10 version 1709
<!-- Node version, npm version, CLI version, operating system, browser -->
