### PR TITLE
Prevent Route Flickers (V2) 🎉

### DIFF
--- a/src/components/async.js
+++ b/src/components/async.js
@@ -10,17 +10,17 @@ export default function(req) {
 			req(m => {
 				this.setState({ child: m.default || m });
 			});
-		}
+		};
 
 		this.shouldComponentUpdate = (_, nxt) => {
 			nxt = nxt.child === void 0;
 			if (nxt && old === void 0) {
-				old = (0, _preact.h)(b.nodeName, { dangerouslySetInnerHTML: { __html: b.innerHTML } });
+				old = h(b.nodeName, { dangerouslySetInnerHTML: { __html: b.innerHTML } });
 			} else {
 				old = ''; // dump it
 			}
 			return !nxt;
-		}
+		};
 
 		this.render = (p, s) => s.child ? h(s.child, p) : old;
 	}

--- a/src/components/async.js
+++ b/src/components/async.js
@@ -1,16 +1,29 @@
 import { h, Component } from 'preact';
 
-export default function(load) {
+export default function(req) {
 	function Async() {
 		Component.call(this);
-		let done = child => {
-			this.setState({ child: child && child.default || child });
-		};
-		let r = load(done);
-		if (r && r.then) r.then(done);
+
+		let b, old;
+		this.componentWillMount = () => {
+			b = this.base = this.nextBase || this.__b; // short circuits 1st render
+			req(m => {
+				this.setState({ child: m.default || m });
+			});
+		}
+
+		this.shouldComponentUpdate = (_, nxt) => {
+			nxt = nxt.child === void 0;
+			if (nxt && old === void 0) {
+				old = (0, _preact.h)(b.nodeName, { dangerouslySetInnerHTML: { __html: b.innerHTML } });
+			} else {
+				old = ''; // dump it
+			}
+			return !nxt;
+		}
+
+		this.render = (p, s) => s.child ? h(s.child, p) : old;
 	}
-	Async.prototype = new Component;
-	Async.prototype.constructor = Async;
-	Async.prototype.render = (props, state) => state.child ? h(state.child, props) : null;
+	(Async.prototype = new Component).constructor = Async;
 	return Async;
 }

--- a/src/lib/webpack/async-component-loader.js
+++ b/src/lib/webpack/async-component-loader.js
@@ -1,7 +1,9 @@
+'use strict';
+
 var loaderUtils = require('loader-utils');
 
-module.exports = function() {};
-module.exports.pitch = function(remainingRequest) {
+module.exports = function () {};
+module.exports.pitch = function (remainingRequest) {
 	this.cacheable && this.cacheable();
 	var query = loaderUtils.getOptions(this) || {};
 	var routeName = typeof query.name === 'function' ? query.name(this.resourcePath) : null;
@@ -15,14 +17,14 @@ module.exports.pitch = function(remainingRequest) {
 	}
 
 	return `
-		import async from 'preact-cli/async-component';
+		import Async from 'preact-cli/async-component';
 
 		function load(cb) {
-			require.ensure([], function(require) {
-				cb(require(${ loaderUtils.stringifyRequest(this, "!!" + remainingRequest) }));
+			require.ensure([], function (require) {
+				cb( require(${loaderUtils.stringifyRequest(this, "!!" + remainingRequest)}) );
 			}${name ? (', '+JSON.stringify(name)) : ''});
 		}
 
-		export default async(load);
+		export default Async(load);
 	`;
 };


### PR DESCRIPTION
Changes our `Async` component so that it `dangerouslySetsInnerHTML` with the existing (SSR) markup. The second cycle is initiated via `require.ensure`'s payload, which `Async` uses to update `state.child`. At this point, we've loaded the `route-*` chunk and have a client-side Preact app.

For sequential routing, the old/stale content _is_ removed while the new chunk downloads. IMO, this is a better approach than holding onto the content until the update is ready, as it would feel frozen/stuck to the visitor.

Contrary to #364, this approach ***does not*** mount the entire `<App/>` twice. 👍 

Demo: [_Video_](https://www.dropbox.com/s/9t1fsudsm2e1czf/route-async.mp4?dl=0)

---

_Closes #364, #281_