### PR TITLE
prevent TypeError when stats is undefined

### DIFF
--- a/src/lib/webpack/run-webpack.js
+++ b/src/lib/webpack/run-webpack.js
@@ -106,8 +106,11 @@ async function prodBuild(env) {
 
 const runCompiler = compiler => new Promise((res, rej) => {
 	compiler.run((err, stats) => {
-		if (err || stats.hasErrors()) {
+		if (stats && stats.hasErrors()) {
 			showStats(stats);
+		}
+
+		if (err || (stats && stats.hasErrors())) {
 			rej(chalk.red('Build failed!'));
 		}
 

--- a/src/lib/webpack/run-webpack.js
+++ b/src/lib/webpack/run-webpack.js
@@ -111,7 +111,7 @@ const runCompiler = compiler => new Promise((res, rej) => {
 		}
 
 		if (err || (stats && stats.hasErrors())) {
-			rej(chalk.red('Build failed!'));
+			rej(chalk.red('Build failed! ' + err));
 		}
 
 		res(stats);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
No. But I will if this is necessary for this.

**Summary**
As I'm working on my personal website, I'm trying to implement the [preact-cli-plugin-critical-css](https://github.com/matthewlynch/preact-cli-plugin-critical-css) plugin.

I was facing an error: 
```shell
Fatal TypeError: Cannot read property 'toJson' of undefined
```

This was caused by this lines: https://github.com/developit/preact-cli/blob/master/src/lib/webpack/run-webpack.js#L109-L119

There was an error, but stats is undefined. As there is an error, we will also show the stats.
This PR will only show stats when there are stats.

**Output before:**
![image](https://user-images.githubusercontent.com/5346497/36034250-c460dab4-0db3-11e8-8cf2-abe88c6f8b06.png)

**Output after:**
![image](https://user-images.githubusercontent.com/5346497/36034261-cb789666-0db3-11e8-8352-1bc653cb8794.png)

**Does this PR introduce a breaking change?**
No

**Other information**
- Node version: v8.0.0, v6.7.0
- npm version: 5.0.0
- CLI version: latest
- Operating System: macOS High Sierra: 10.13.2
- Browser: Irrelevant 
