### PR TITLE
Ignore `.git` files within SW Assets

### DIFF
--- a/src/lib/webpack/webpack-client-config.js
+++ b/src/lib/webpack/webpack-client-config.js
@@ -150,7 +150,7 @@ function isProd(config) {
 					/\.map$/,
 					/push-manifest\.json$/,
 					/.DS_Store/,
-					/^\.git/
+					/\.git/
 				]
 			}),
 			new webpack.DefinePlugin({

--- a/src/lib/webpack/webpack-client-config.js
+++ b/src/lib/webpack/webpack-client-config.js
@@ -149,7 +149,8 @@ function isProd(config) {
 					/polyfills(\..*)?\.js$/,
 					/\.map$/,
 					/push-manifest\.json$/,
-					/.DS_Store/
+					/.DS_Store/,
+					/^\.git/
 				]
 			}),
 			new webpack.DefinePlugin({


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No

**Summary**

You can accidentally include `.git*` files inside your `sw-precache` assets, especially with a non-standard directory setup. For example, having `src/assets/.gitkeep` will try to cache `.gitkeep` at runtime, resulting in this error.

```
Uncaught (in promise) Error: Request for https://.../assets/icons/.gitkeep?_sw-precache=d41d8cd98f00b204e9800998ecf8427e returned a response with status 404
```
