### PR TITLE
Enable webpack devServer overlay for compiler errors

### DIFF
--- a/src/lib/webpack/webpack-client-config.js
+++ b/src/lib/webpack/webpack-client-config.js
@@ -185,7 +185,7 @@ function isDev(config) {
 			historyApiFallback: true,
 			quiet: true,
 			clientLogLevel: 'none',
-			overlay: false,
+			overlay: true,
 			stats: 'minimal',
 			watchOptions: {
 				ignored: [


### PR DESCRIPTION
Shows a full-screen overlay in the browser when there are compiler errors.
https://webpack.js.org/configuration/dev-server/#devserver-overlay

![screen shot 2018-02-12 at 22 16 38](https://user-images.githubusercontent.com/464300/36120534-c9099884-1043-11e8-8486-75cd61c792fd.png) 
