### PR TITLE
decorators must come before class-properties

### DIFF
--- a/src/lib/babel-config.js
+++ b/src/lib/babel-config.js
@@ -20,10 +20,10 @@ export default (env, options={}) => {
 		plugins: [
 			require.resolve('babel-plugin-syntax-dynamic-import'),
 			require.resolve('babel-plugin-transform-object-assign'),
+			require.resolve('babel-plugin-transform-decorators-legacy'),
 			require.resolve('babel-plugin-transform-class-properties'),
 			require.resolve('babel-plugin-transform-export-extensions'),
 			require.resolve('babel-plugin-transform-object-rest-spread'),
-			require.resolve('babel-plugin-transform-decorators-legacy'),
 			require.resolve('babel-plugin-transform-react-constant-elements'),
 			isProd && require.resolve('babel-plugin-transform-react-remove-prop-types'),
 			[require.resolve('babel-plugin-transform-react-jsx'), { pragma: 'h' }],


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

no

**Summary**

as per [https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy#note-order-of-plugins-matters](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy#note-order-of-plugins-matters) the `babel-plugin-transform-decorators-legacy` plugin should come before `babel-plugin-transform-class-properties`

we use `react-tracking` and it's decorators broke due to the incorrect order.

**Does this PR introduce a breaking change?**

no

**Other information**

N/A