### PR TITLE
Fix: Remove undefined `nodeName` within complex apps

### DIFF
--- a/src/components/async.js
+++ b/src/components/async.js
@@ -14,7 +14,7 @@ export default function(req) {
 
 		this.shouldComponentUpdate = (_, nxt) => {
 			nxt = nxt.child === void 0;
-			if (nxt && old === void 0) {
+			if (nxt && old === void 0 && !!b) {
 				old = h(b.nodeName, { dangerouslySetInnerHTML: { __html: b.innerHTML } });
 			} else {
 				old = ''; // dump it


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

nope

**Summary**

I upgraded an older, more complex Preact CLI app to `2.2.0` and saw that although the _initial_ client->server handoff (#489) was fine, loading & awaiting the next pages' chunks would result in this:

```
Uncaught (in promise) TypeError: Cannot read property 'nodeName' of null
    at Async.shouldComponentUpdate (async.js:25)
    at renderComponent (preact.js:324)
    at setComponentProps (preact.js:300)
    at renderComponent (preact.js:340)
    at setComponentProps (preact.js:300)
    at buildComponentFromVNode (preact.js:398)
    at idiff (preact.js:156)
    at innerDiffNode (preact.js:225)
    at idiff (preact.js:179)
    at diff (preact.js:130)
```

This didn't appear in the official Preact CLI templates, and my guess is because this particular complex app is doing a lot more `require.ensure` calls.

Applying this fix to the Preact CLI templates (and my simpler apps) does not result in any change or regression. This is because `b` is always expected to be truthy, and so `!!b` is just an extra line of defense.

**Does this PR introduce a breaking change?**

No

