### PR TITLE
fixes #291 - replace progress-bar-webpack-plugin with webpack-simple-…

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "preact-compat": "^3.14.3",
     "preact-render-to-string": "^3.6.0",
     "preact-router": "^2.5.2",
-    "progress-bar-webpack-plugin": "^1.9.3",
+    "webpack-simple-progress-plugin": "^0.0.4",
     "promise-polyfill": "^6.0.2",
     "raw-loader": "^0.5.1",
     "require-relative": "^0.8.7",

--- a/src/lib/webpack/webpack-base-config.js
+++ b/src/lib/webpack/webpack-base-config.js
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import { readFileSync } from 'fs';
 import autoprefixer from 'autoprefixer';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
-import ProgressBarPlugin from 'progress-bar-webpack-plugin';
+import SimpleProgressPlugin from 'webpack-simple-progress-plugin';
 import ReplacePlugin from 'webpack-plugin-replace';
 import requireRelative from 'require-relative';
 import createBabelConfig from '../babel-config';
@@ -217,11 +217,10 @@ export default function (env) {
 				async: false,
 				minChunks: 3
 			}),
-			new ProgressBarPlugin({
-				format: '\u001b[90m\u001b[44mBuild\u001b[49m\u001b[39m [:bar] \u001b[32m\u001b[1m:percent\u001b[22m\u001b[39m (:elapseds) \u001b[2m:msg\u001b[22m',
-				renderThrottle: 100,
-				summary: false,
-				clear: true
+			new SimpleProgressPlugin({
+				progressOptions: {
+					clear: true
+				}
 			})
 		].concat(isProd ? [
 			new webpack.HashedModuleIdsPlugin(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3032,7 +3032,7 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -5127,17 +5127,9 @@ object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
-object-keys@^1.0.10, object-keys@^1.0.8:
+object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
-
-object.assign@^4.0.1:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
-  dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.0"
-    object-keys "^1.0.10"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -5836,14 +5828,6 @@ process-nextick-args@~1.0.6:
 process@^0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-
-progress-bar-webpack-plugin@^1.9.3:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/progress-bar-webpack-plugin/-/progress-bar-webpack-plugin-1.10.0.tgz#e0b1063aa03c79e298a9340598590bb61efef9a4"
-  dependencies:
-    chalk "^1.1.1"
-    object.assign "^4.0.1"
-    progress "^1.1.8"
 
 progress@^1.1.8:
   version "1.1.8"
@@ -7522,6 +7506,14 @@ webpack-merge@^4.1.0:
 webpack-plugin-replace@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/webpack-plugin-replace/-/webpack-plugin-replace-1.1.1.tgz#9816647fefc98a7d1700f93f2b4b6f481cf20161"
+
+webpack-simple-progress-plugin@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/webpack-simple-progress-plugin/-/webpack-simple-progress-plugin-0.0.4.tgz#c4829137429cb673dfc6a61a262b955c35cc7ba2"
+  dependencies:
+    chalk "^1.1.3"
+    object-assign "^4.1.0"
+    progress "^1.1.8"
 
 webpack-sources@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
fixes #291 - replace progress-bar-webpack-plugin with webpack-simple-progress-plugin

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
(refactor) uses shiny new `webpack-simple-progress-plugin` over `progress-bar-webpack-plugin`

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No.

**Summary**
closes #291 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!-- Node version, npm version, CLI version, operating system, browser -->
