### PR TITLE
WIP: Provide Option to Specify Hostname in Serve Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ $ preact serve
   --dest      Directory or filename where firebase.json should be written
               (used for --server config)                                      [string]  [default: -]
   --port, -p  Port to start a server on.                                      [string]  [default: PORT || 8080]
+  --host,     Hostname to start a server on                                   [string]  [default: "localhost"]
 ```
 
 #### preact list

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -210,7 +210,7 @@ const SERVERS = {
 			path.relative(options.cwd, options.dir),
 			'--gzip',
 			'-p', options.port,
-			'--host', options.host
+			'--host', options.host,
 			'-c', JSON.stringify({ ...options.configObj, public: undefined })
 		];
 	},

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -40,6 +40,11 @@ export default asyncCommand({
 			defaultDescription: 'PORT || 8080',
 			alias: 'p'
 		},
+		host: {
+			description: 'Hostname to start a server on',
+			default: 'localhost',
+			alias: 'H'
+		},
 		cors: {
 			description: 'Set allowed origins',
 			defaultDescription: 'https://localhost:${PORT}'
@@ -205,6 +210,7 @@ const SERVERS = {
 			path.relative(options.cwd, options.dir),
 			'--gzip',
 			'-p', options.port,
+			'--host', options.host
 			'-c', JSON.stringify({ ...options.configObj, public: undefined })
 		];
 	},


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

This is a new feature.

**Did you add tests for your changes?**

No, I have not yet added tests. I want to first validate that this feature can be added.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

In some production environments the default hostname of `localhost` is not sufficient. For example, when deploying to IBM Cloud (and likely other Cloud Foundry environments) we need the option to specific the hostname as `0.0.0.0`. This feature adds a `--host` option to the `serve` command.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

I don't believe this introduces any breaking changes.

**Other information**

<!-- Node version, npm version, CLI version, operating system, browser -->

Note that this feature currently only works with `superstatic` server option. Before merging this pull request:

- [ ] Validate that this does not introduce any breaking changes.
- [ ] Determine the implications and feasibility of specifying the hostname with `simplehttp2server` and `config` server options.
- [ ] Add appropriate inline documentation.
- [ ] Add unit tests.