### PR TITLE
Inject NODE_ENV via DefinePlugin

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -196,6 +196,9 @@ module.exports = function (env) {
 
 		plugins: [
 			new webpack.NoEmitOnErrorsPlugin(),
+			new webpack.DefinePlugin({
+				'process.env.NODE_ENV': JSON.stringify(isProd ? 'production' : 'development')
+			}),
 			new webpack.ProvidePlugin({
 				h: ['preact', 'h'],
 			}),


### PR DESCRIPTION
This includes a `NODE_ENV` value once again. We removed it in #564 but Webpack4 doesn't auto-inject the value for it -- it only manages/swaps build settings based on the `mode` value.

The other (and probably more correct) way of doing this is this:

```js
new webpack.EnvironmentPlugin({
  NODE_ENV: 'development' // use 'development' unless process.env.NODE_ENV is defined
})
```

...but (1) we're already managing the `isProd` value and (2) one of the patterns a lot of us have been using is to append custom definitions within our `preact.config.js` files, like [this](https://github.com/developit/oss.ninja/blob/master/preact.config.js#L20).