### PR TITLE
update style-loader to 0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "simplehttp2server": "^2.0.0",
     "source-map": "^0.5.6",
     "stack-trace": "0.0.10",
-    "style-loader": "^0.18.2",
+    "style-loader": "^0.21.0",
     "sw-precache-webpack-plugin": "^0.11.2",
     "tmp": "0.0.31",
     "unfetch": "^3.0.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Updates the `style-loader` package to the latest version (0.21.0).

**Did you add tests for your changes?**

n/a

**Summary**

I'd like to be able to target an iframe with the `insertInto` option of `style-loader` (using preact.config.js). This allows your styles to be inserted into the iframe's head (see https://github.com/webpack-contrib/style-loader/pull/248). The current version of `style-loader` used by `preact-cli` (0.18.2) doesn't have this feature - it was introduced in 0.19.0.

The reason I need this is that I'm building an embeddable Preact widget that'll be rendered into the body of a sourceless iframe, and so that's where I'd like my styles to be inserted.

**Does this PR introduce a breaking change?**

It shouldn't - I couldn't find any breaking changes in the `style-loader` changelog.
