### PR TITLE
fixes "is only allowed in root programmatic options" with latest jest

### DIFF
--- a/packages/cli/lib/lib/babel-config.js
+++ b/packages/cli/lib/lib/babel-config.js
@@ -2,7 +2,6 @@ module.exports = function (env, options={}) {
 	const isProd = env && env.production;
 
 	return {
-		babelrc: false,
 		presets: [
 			[require.resolve('@babel/preset-env'), {
 				loose: true,

--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -73,6 +73,7 @@ module.exports = function (env) {
 					test: /\.jsx?$/,
 					loader: 'babel-loader',
 					options: Object.assign(
+						{ babelrc: false },
 						createBabelConfig(env, { browsers }),
 						babelrc // intentionally overwrite our settings
 					)


### PR DESCRIPTION
To re-create error run:

```
preact create default preact-next
cd preact-next
npm i -D jest@latest preact-cli@next 'babel-core@^7.0.0-0' @babel/core
touch preact.config.js
jest ./tests --no-cache
```

Will throw:

```
 FAIL  src/tests/header.test.js
  ● Test suite failed to run

    [BABEL] /Users/cj/apps/vodr/preact-next/src/tests/__mocks__/browserMocks.js: .babelrc is only allowed in root programmatic options, or babel.config.js/config file options

      at Object.keys.forEach.key (node_modules/@babel/core/lib/config/validation/options.js:83:13)
          at Array.forEach (<anonymous>)
      at validate (node_modules/@babel/core/lib/config/validation/options.js:69:21)
      at instantiatePreset (node_modules/@babel/core/lib/config/full.js:236:36)
      at cachedFunction (node_modules/@babel/core/lib/config/caching.js:32:19)
      at loadPresetDescriptor (node_modules/@babel/core/lib/config/full.js:227:45)
      at config.presets.map.descriptor (node_modules/@babel/core/lib/config/full.js:72:19)
          at Array.map (<anonymous>)
      at recurseDescriptors (node_modules/@babel/core/lib/config/full.js:70:38)
      at loadFullConfig (node_modules/@babel/core/lib/config/full.js:100:6)
```

We also could use [babelrcRoots](https://babeljs.io/docs/en/next/babel-core.html#babelrcRoots)??