### PR TITLE
Build service worker for --esm

### DIFF
--- a/packages/cli/lib/lib/entry.js
+++ b/packages/cli/lib/lib/entry.js
@@ -5,8 +5,8 @@ if (process.env.NODE_ENV==='development') {
 	require('preact/debug');
 }
 else if (process.env.ADD_SW && 'serviceWorker' in navigator) {
-  // eslint-disable-next-line no-undef
-  navigator.serviceWorker.register(__webpack_public_path__ + process.env.ES_BUILD? 'sw-esm.js' : 'sw.js');
+	// eslint-disable-next-line no-undef
+	navigator.serviceWorker.register(__webpack_public_path__ + process.env.ES_BUILD? 'sw-esm.js' : 'sw.js');
 }
 
 const interopDefault = m => m && m.default ? m.default : m;

--- a/packages/cli/lib/lib/entry.js
+++ b/packages/cli/lib/lib/entry.js
@@ -5,8 +5,8 @@ if (process.env.NODE_ENV==='development') {
 	require('preact/debug');
 }
 else if (process.env.ADD_SW && 'serviceWorker' in navigator) {
-	// eslint-disable-next-line no-undef
-	navigator.serviceWorker.register(__webpack_public_path__ + 'sw.js');
+  // eslint-disable-next-line no-undef
+  navigator.serviceWorker.register(__webpack_public_path__ + process.env.ES_BUILD? 'sw-esm.js' : 'sw.js');
 }
 
 const interopDefault = m => m && m.default ? m.default : m;

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -169,6 +169,7 @@ function isProd(config) {
 				minify: true,
 				stripPrefix: config.cwd,
 				staticFileGlobsIgnorePatterns: [
+          /\.esm\.js$/,
 					/polyfills(\..*)?\.js$/,
 					/\.map$/,
 					/push-manifest\.json$/,
@@ -185,7 +186,26 @@ function isProd(config) {
 				filename: '[name].[chunkhash:5].esm.js',
 				chunkFilename: '[name].chunk.[chunkhash:5].esm.js'
 			}),
-		);
+    );
+    if (config.sw) {
+      prodConfig.plugins.push(
+        new SWPrecacheWebpackPlugin({
+          filename: 'sw-esm.js',
+          navigateFallback: 'index.html',
+          navigateFallbackWhitelist: [/^(?!\/__).*/],
+          minify: true,
+          stripPrefix: config.cwd,
+          staticFileGlobsIgnorePatterns: [
+            /(\.[\w]{5}\.js)/,
+            /polyfills(\..*)?\.js$/,
+            /\.map$/,
+            /push-manifest\.json$/,
+            /.DS_Store/,
+            /\.git/
+          ]
+        }),
+      );
+    }
 	}
 
 	if (config.analyze) {

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -109,7 +109,8 @@ function isProd(config) {
 		plugins: [
 			new webpack.DefinePlugin({
 				'process.env.ADD_SW': config.sw,
-				'process.env.ESM': config.esm
+        'process.env.ESM': config.esm,
+        'process.env.ES_BUILD': false,
 			})
 		],
 
@@ -184,7 +185,20 @@ function isProd(config) {
 		prodConfig.plugins.push(
 			new BabelEsmPlugin({
 				filename: '[name].[chunkhash:5].esm.js',
-				chunkFilename: '[name].chunk.[chunkhash:5].esm.js'
+        chunkFilename: '[name].chunk.[chunkhash:5].esm.js',
+        beforeStartExecution: plugins => {
+          plugins.forEach(plugin => {
+            if (plugin.constructor.name === 'DefinePlugin' && plugin.definitions) {
+              for (const definition in plugin.definitions) {
+                if (definition === 'process.env.ES_BUILD') {
+                  plugin.definitions[definition] = true;
+                }
+              }
+            } else if (plugin.constructor.name === 'DefinePlugin' && !plugin.definitions) {
+              throw new Error('WebpackDefinePlugin found but not `process.env.ES_BUILD`.');
+            }
+          })
+        },
 			}),
     );
     if (config.sw) {

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -109,8 +109,8 @@ function isProd(config) {
 		plugins: [
 			new webpack.DefinePlugin({
 				'process.env.ADD_SW': config.sw,
-        'process.env.ESM': config.esm,
-        'process.env.ES_BUILD': false,
+				'process.env.ESM': config.esm,
+				'process.env.ES_BUILD': false,
 			})
 		],
 
@@ -170,7 +170,7 @@ function isProd(config) {
 				minify: true,
 				stripPrefix: config.cwd,
 				staticFileGlobsIgnorePatterns: [
-          /\.esm\.js$/,
+					/\.esm\.js$/,
 					/polyfills(\..*)?\.js$/,
 					/\.map$/,
 					/push-manifest\.json$/,
@@ -185,41 +185,41 @@ function isProd(config) {
 		prodConfig.plugins.push(
 			new BabelEsmPlugin({
 				filename: '[name].[chunkhash:5].esm.js',
-        chunkFilename: '[name].chunk.[chunkhash:5].esm.js',
-        beforeStartExecution: plugins => {
-          plugins.forEach(plugin => {
-            if (plugin.constructor.name === 'DefinePlugin' && plugin.definitions) {
-              for (const definition in plugin.definitions) {
-                if (definition === 'process.env.ES_BUILD') {
-                  plugin.definitions[definition] = true;
-                }
-              }
-            } else if (plugin.constructor.name === 'DefinePlugin' && !plugin.definitions) {
-              throw new Error('WebpackDefinePlugin found but not `process.env.ES_BUILD`.');
-            }
-          })
-        },
+				chunkFilename: '[name].chunk.[chunkhash:5].esm.js',
+				beforeStartExecution: plugins => {
+					plugins.forEach(plugin => {
+						if (plugin.constructor.name === 'DefinePlugin' && plugin.definitions) {
+							for (const definition in plugin.definitions) {
+								if (definition === 'process.env.ES_BUILD') {
+									plugin.definitions[definition] = true;
+								}
+							}
+						} else if (plugin.constructor.name === 'DefinePlugin' && !plugin.definitions) {
+							throw new Error('WebpackDefinePlugin found but not `process.env.ES_BUILD`.');
+						}
+					})
+				},
 			}),
-    );
-    if (config.sw) {
-      prodConfig.plugins.push(
-        new SWPrecacheWebpackPlugin({
-          filename: 'sw-esm.js',
-          navigateFallback: 'index.html',
-          navigateFallbackWhitelist: [/^(?!\/__).*/],
-          minify: true,
-          stripPrefix: config.cwd,
-          staticFileGlobsIgnorePatterns: [
-            /(\.[\w]{5}\.js)/,
-            /polyfills(\..*)?\.js$/,
-            /\.map$/,
-            /push-manifest\.json$/,
-            /.DS_Store/,
-            /\.git/
-          ]
-        }),
-      );
-    }
+		);
+		if (config.sw) {
+			prodConfig.plugins.push(
+				new SWPrecacheWebpackPlugin({
+					filename: 'sw-esm.js',
+					navigateFallback: 'index.html',
+					navigateFallbackWhitelist: [/^(?!\/__).*/],
+					minify: true,
+					stripPrefix: config.cwd,
+					staticFileGlobsIgnorePatterns: [
+						/(\.[\w]{5}\.js)/,
+						/polyfills(\..*)?\.js$/,
+						/\.map$/,
+						/push-manifest\.json$/,
+						/.DS_Store/,
+						/\.git/
+					]
+				}),
+			);
+		}
 	}
 
 	if (config.analyze) {

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -197,7 +197,7 @@ function isProd(config) {
 						} else if (plugin.constructor.name === 'DefinePlugin' && !plugin.definitions) {
 							throw new Error('WebpackDefinePlugin found but not `process.env.ES_BUILD`.');
 						}
-					})
+					});
 				},
 			}),
 		);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
     "@babel/preset-env": "^7.0.0-beta.51",
     "@babel/register": "^7.0.0-beta.51",
     "autoprefixer": "^8.4.1",
-    "babel-esm-plugin": "0.0.9",
+    "babel-esm-plugin": "0.1.1",
     "babel-loader": "^8.0.0-beta.3",
     "babel-plugin-jsx-pragmatic": "^1.0.2",
     "babel-plugin-transform-export-extensions": "^6.22.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This completes the `service-worker` story for the `--esm` builds.

**Did you add tests for your changes?**
No 🤓 

**Summary**
Now there will be two service workers `sw` and `sw-esm` which will precache es5 and esm builds respectively. This will also register the right service worker based on the bundle.

Also this introduces an environment variable which tells the code which build is being executed. ES5 or ESM.

**Does this PR introduce a breaking change?**
Nah!