### PR TITLE
Add host option to superstatic server

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ $ preact serve
               [options: "simplehttp2server", "superstatic", "config"]         [string]  [default: "simplehttp2server"]
   --dest      Directory or filename where firebase.json should be written
               (used for --server config)                                      [string]  [default: -]
+  --host, -h  Host to allow connections from (superstatic only).              [string]  [default: HOST || "localhost"]
   --port, -p  Port to start a server on.                                      [string]  [default: PORT || 8080]
+  --cors      Set allowed origins (simplehttp2server only).                   [string]  [default: "https://localhost:${PORT}"]
 ```
 
 #### preact list

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -35,13 +35,18 @@ export default asyncCommand({
 			description: 'Directory or filename where firebase.json should be written\n  (used for --server config)',
 			defaultDescription: '-'
 		},
+		host: {
+			description: 'Host to allow connections from (superstatic only).',
+			defaultDescription: 'HOST || localhost',
+			alias: 'h'
+		},
 		port: {
 			description: 'Port to start a server on.',
 			defaultDescription: 'PORT || 8080',
 			alias: 'p'
 		},
 		cors: {
-			description: 'Set allowed origins',
+			description: 'Set allowed origins (simplehttp2server only).',
 			defaultDescription: 'https://localhost:${PORT}'
 		}
 	},

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -204,6 +204,7 @@ const SERVERS = {
 			'superstatic',
 			path.relative(options.cwd, options.dir),
 			'--gzip',
+			'-h', options.host,
 			'-p', options.port,
 			'-c', JSON.stringify({ ...options.configObj, public: undefined })
 		];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Feature.

**Did you add tests for your changes?**

No. The change is simple enough and it could be challenging to test connections from a different host.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Let me start this by saying I'm a fan of `preact-cli` and the simplicity it provides developers to get started quickly. As it stands now, it's set up for local development which is fine for the majority of use cases.

In my specific case, my team is developing an app for smart TV devices and need to serve to them over a LAN. We _could_ set up a proxy to do this but why complicate things when it's simple to do directly from `superstatic`. It would be a similar issue for any developers wishing to develop on mobile.

The caveat here is only `superstatic` supports the `host` option (much like only `simplehttp2server` supports the `cors` option). I updated the async-command description to reflect that.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**Other information**

<!-- Node version, npm version, CLI version, operating system, browser -->

Not relevant.