### PR TITLE
No json loader

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -179,10 +179,6 @@ module.exports = function (env) {
 						}
 					],
 				},
-				{ // Arbitrary file loaders
-					test: /\.json$/,
-					loader: 'json-loader'
-				},
 				{
 					test: /\.(xml|html|txt|md)$/,
 					loader: 'raw-loader'

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -80,7 +80,6 @@
     "inquirer": "^5.2.0",
     "ip": "^1.1.5",
     "isomorphic-unfetch": "^2.0.0",
-    "json-loader": "^0.5.4",
     "loader-utils": "^1.1.0",
     "log-symbols": "^2.1.0",
     "mini-css-extract-plugin": "^0.4.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes #613 

**Did you add tests for your changes?**
No

**Summary**
`json-loader` is no more required, it is by default handled by webpack

**Does this PR introduce a breaking change?**
no
