### PR TITLE
Esm push fixes

### DIFF
--- a/packages/cli/lib/lib/webpack/create-load-manifest.js
+++ b/packages/cli/lib/lib/webpack/create-load-manifest.js
@@ -32,7 +32,7 @@ module.exports = (assets, isESMBuild = false) => {
     },
   },
   manifest = {
-  '/': defaults
+    '/': defaults
   };
 
   let path, css, obj;
@@ -42,8 +42,7 @@ module.exports = (assets, isESMBuild = false) => {
     obj[filename] = { type:'script', weight:0.9 };
     if (css) obj[css] = { type:'style', weight:0.9 };
     path = filename.replace(/route-/, '/')
-      .replace(/\.chunk(\.\w+)?\.js$/, '')
-      .replace(/\.chunk(\.\w+)?\.esm\.js$/, '')
+      .replace(/\.chunk(\.\w+)?(\.esm)?\.js$/, '')
       .replace(/\/home/, '/');
     manifest[path] = obj;
   });

--- a/packages/cli/lib/lib/webpack/create-load-manifest.js
+++ b/packages/cli/lib/lib/webpack/create-load-manifest.js
@@ -1,15 +1,20 @@
-module.exports = assets => {
+module.exports = (assets, isESMBuild) => {
   let mainJs, mainCss, scripts=[], styles=[];
   for (let filename in assets) {
     if (!/\.map$/.test(filename)) {
-      if (/route-/.test(filename)) {
+      if (/route-/.test(filename) && !isESMBuild) {
+        scripts.push(filename);
+      } else if (/route-(.+)\.esm\.js/.test(filename) && isESMBuild) {
         scripts.push(filename);
       } else if (/chunk\.(.+)\.css$/.test(filename)) {
         styles.push(filename);
       } else if (/^bundle(.+)\.css$/.test(filename)) {
         mainCss = filename;
-      } else if (/^bundle(.+)\.js$/.test(filename)) {
+      } else if (!isESMBuild && /^bundle(.+)\.js$/.test(filename)) {
         mainJs = filename;
+      } else if (isESMBuild && /bundle\.\w{5}\.esm\.js/.test(filename)) {
+        mainJs = filename;
+        console.log('setting filename');
       }
     }
   }

--- a/packages/cli/lib/lib/webpack/create-load-manifest.js
+++ b/packages/cli/lib/lib/webpack/create-load-manifest.js
@@ -14,7 +14,6 @@ module.exports = (assets, isESMBuild) => {
         mainJs = filename;
       } else if (isESMBuild && /bundle\.\w{5}\.esm\.js/.test(filename)) {
         mainJs = filename;
-        console.log('setting filename');
       }
     }
   }

--- a/packages/cli/lib/lib/webpack/create-load-manifest.js
+++ b/packages/cli/lib/lib/webpack/create-load-manifest.js
@@ -24,9 +24,7 @@ module.exports = assets => {
       weight: 1
     },
   },
-  manifest = {
-    '/': defaults
-  };
+  manifest = {};
 
   let path, css, obj;
   scripts.forEach((filename, idx) => {
@@ -34,8 +32,15 @@ module.exports = assets => {
     obj = Object.assign({}, defaults);
     obj[filename] = { type:'script', weight:0.9 };
     if (css) obj[css] = { type:'style', weight:0.9 };
-    path = filename.replace(/route-/, '/').replace(/\.chunk(\.\w+)?\.js$/, '').replace(/\/home/, '/');
-    manifest[path] = obj;
+    path = filename.replace(/route-/, '/')
+      .replace(/\.chunk(\.\w+)?\.js$/, '')
+      .replace(/\.chunk(\.\w+)?\.esm\.js$/, '')
+      .replace(/\/home/, '/');
+    if (!manifest[path]) {
+      manifest[path] = obj;
+    } else {
+      manifest[path][filename] = { type:'script', weight:0.9 };
+    }
   });
 
   return manifest;

--- a/packages/cli/lib/lib/webpack/create-load-manifest.js
+++ b/packages/cli/lib/lib/webpack/create-load-manifest.js
@@ -1,19 +1,22 @@
-module.exports = (assets, isESMBuild) => {
+const isESM = filename => /\.esm\.js$/.test(filename);
+const isMatch = (filename, condition) => (isESM(filename) === condition);
+
+module.exports = (assets, isESMBuild = false) => {
   let mainJs, mainCss, scripts=[], styles=[];
   for (let filename in assets) {
     if (!/\.map$/.test(filename)) {
-      if (/route-/.test(filename) && !isESMBuild) {
-        scripts.push(filename);
-      } else if (/route-(.+)\.esm\.js/.test(filename) && isESMBuild) {
-        scripts.push(filename);
+      if (/route-/.test(filename)) {
+        // both ESM & regular match here
+        isMatch(filename, isESMBuild) && scripts.push(filename);
       } else if (/chunk\.(.+)\.css$/.test(filename)) {
         styles.push(filename);
       } else if (/^bundle(.+)\.css$/.test(filename)) {
         mainCss = filename;
-      } else if (!isESMBuild && /^bundle(.+)\.js$/.test(filename)) {
-        mainJs = filename;
-      } else if (isESMBuild && /bundle\.\w{5}\.esm\.js/.test(filename)) {
-        mainJs = filename;
+      } else if (/^bundle(.+)\.js$/.test(filename)) {
+        // both ESM & regular bundles match here
+        if (isMatch(filename, isESMBuild)) {
+          mainJs = filename;
+        }
       }
     }
   }

--- a/packages/cli/lib/lib/webpack/create-load-manifest.js
+++ b/packages/cli/lib/lib/webpack/create-load-manifest.js
@@ -1,52 +1,50 @@
 module.exports = (assets, isESMBuild) => {
-  let mainJs, mainCss, scripts=[], styles=[];
-  for (let filename in assets) {
-    if (!/\.map$/.test(filename)) {
-      if (/route-/.test(filename) && !isESMBuild) {
-        scripts.push(filename);
-      } else if (/route-(.+)\.esm\.js/.test(filename) && isESMBuild) {
-        scripts.push(filename);
-      } else if (/chunk\.(.+)\.css$/.test(filename)) {
-        styles.push(filename);
-      } else if (/^bundle(.+)\.css$/.test(filename)) {
-        mainCss = filename;
-      } else if (!isESMBuild && /^bundle(.+)\.js$/.test(filename)) {
-        mainJs = filename;
-      } else if (isESMBuild && /bundle\.\w{5}\.esm\.js/.test(filename)) {
-        mainJs = filename;
-      }
-    }
-  }
+	let mainJs, mainCss, scripts=[], styles=[];
+	for (let filename in assets) {
+		if (!/\.map$/.test(filename)) {
+			if (/route-/.test(filename) && !isESMBuild) {
+				scripts.push(filename);
+			} else if (/route-(.+)\.esm\.js/.test(filename) && isESMBuild) {
+				scripts.push(filename);
+			} else if (/chunk\.(.+)\.css$/.test(filename)) {
+				styles.push(filename);
+			} else if (/^bundle(.+)\.css$/.test(filename)) {
+				mainCss = filename;
+			} else if (!isESMBuild && /^bundle(.+)\.js$/.test(filename)) {
+				mainJs = filename;
+			} else if (isESMBuild && /bundle\.\w{5}\.esm\.js/.test(filename)) {
+				mainJs = filename;
+			}
+		}
+	}
 
-  let defaults = {
-    [mainCss]: {
-      type: 'style',
-      weight: 1
-    },
-    [mainJs]: {
-      type: 'script',
-      weight: 1
-    },
-  },
-  manifest = {};
+	let defaults = {
+		[mainCss]: {
+			type: 'style',
+			weight: 1
+		},
+		[mainJs]: {
+			type: 'script',
+			weight: 1
+		},
+	},
+	manifest = {
+	'/': defaults
+	};
 
-  let path, css, obj;
-  scripts.forEach((filename, idx) => {
-    css = styles[idx];
-    obj = Object.assign({}, defaults);
-    obj[filename] = { type:'script', weight:0.9 };
-    if (css) obj[css] = { type:'style', weight:0.9 };
-    path = filename.replace(/route-/, '/')
-      .replace(/\.chunk(\.\w+)?\.js$/, '')
-      .replace(/\.chunk(\.\w+)?\.esm\.js$/, '')
-      .replace(/\/home/, '/');
-    if (!manifest[path]) {
-      manifest[path] = obj;
-    } else {
-      manifest[path][filename] = { type:'script', weight:0.9 };
-    }
-  });
+	let path, css, obj;
+	scripts.forEach((filename, idx) => {
+		css = styles[idx];
+		obj = Object.assign({}, defaults);
+		obj[filename] = { type:'script', weight:0.9 };
+		if (css) obj[css] = { type:'style', weight:0.9 };
+		path = filename.replace(/route-/, '/')
+			.replace(/\.chunk(\.\w+)?\.js$/, '')
+			.replace(/\.chunk(\.\w+)?\.esm\.js$/, '')
+			.replace(/\/home/, '/');
+		manifest[path] = obj;
+	});
 
-  return manifest;
+	return manifest;
 };
 

--- a/packages/cli/lib/lib/webpack/create-load-manifest.js
+++ b/packages/cli/lib/lib/webpack/create-load-manifest.js
@@ -2,52 +2,51 @@ const isESM = filename => /\.esm\.js$/.test(filename);
 const isMatch = (filename, condition) => (isESM(filename) === condition);
 
 module.exports = (assets, isESMBuild = false) => {
-  let mainJs, mainCss, scripts=[], styles=[];
-  for (let filename in assets) {
-    if (!/\.map$/.test(filename)) {
-      if (/route-/.test(filename)) {
-        // both ESM & regular match here
-        isMatch(filename, isESMBuild) && scripts.push(filename);
-      } else if (/chunk\.(.+)\.css$/.test(filename)) {
-        styles.push(filename);
-      } else if (/^bundle(.+)\.css$/.test(filename)) {
-        mainCss = filename;
-      } else if (/^bundle(.+)\.js$/.test(filename)) {
-        // both ESM & regular bundles match here
-        if (isMatch(filename, isESMBuild)) {
-          mainJs = filename;
-        }
-      }
-    }
-  }
+	let mainJs, mainCss, scripts=[], styles=[];
+	for (let filename in assets) {
+		if (!/\.map$/.test(filename)) {
+			if (/route-/.test(filename)) {
+				// both ESM & regular match here
+				isMatch(filename, isESMBuild) && scripts.push(filename);
+			} else if (/chunk\.(.+)\.css$/.test(filename)) {
+				styles.push(filename);
+			} else if (/^bundle(.+)\.css$/.test(filename)) {
+				mainCss = filename;
+			} else if (/^bundle(.+)\.js$/.test(filename)) {
+				// both ESM & regular bundles match here
+				if (isMatch(filename, isESMBuild)) {
+					mainJs = filename;
+				}
+			}
+		}
+	}
 
-  let defaults = {
-    [mainCss]: {
-      type: 'style',
-      weight: 1
-    },
-    [mainJs]: {
-      type: 'script',
-      weight: 1
-    },
-  },
-  manifest = {
-    '/': defaults
-  };
+	let defaults = {
+		[mainCss]: {
+			type: 'style',
+			weight: 1
+		},
+		[mainJs]: {
+			type: 'script',
+			weight: 1
+		},
+	},
+	manifest = {
+		'/': defaults
+	};
 
-  let path, css, obj;
-  scripts.forEach((filename, idx) => {
-    css = styles[idx];
-    obj = Object.assign({}, defaults);
-    obj[filename] = { type:'script', weight:0.9 };
-    if (css) obj[css] = { type:'style', weight:0.9 };
-    path = filename.replace(/route-/, '/')
-      .replace(/\.chunk(\.\w+)?\.js$/, '')
-      .replace(/\.chunk(\.\w+)?\.esm\.js$/, '')
-      .replace(/\/home/, '/');
-    manifest[path] = obj;
-  });
+	let path, css, obj;
+	scripts.forEach((filename, idx) => {
+		css = styles[idx];
+		obj = Object.assign({}, defaults);
+		obj[filename] = { type:'script', weight:0.9 };
+		if (css) obj[css] = { type:'style', weight:0.9 };
+		path = filename.replace(/route-/, '/')
+			.replace(/\.chunk(\.\w+)?(\.esm)?\.js$/, '')
+			.replace(/\/home/, '/');
+		manifest[path] = obj;
+	});
 
-  return manifest;
+	return manifest;
 };
 

--- a/packages/cli/lib/lib/webpack/push-manifest.js
+++ b/packages/cli/lib/lib/webpack/push-manifest.js
@@ -1,9 +1,12 @@
 const createLoadManifest = require('./create-load-manifest');
 
 module.exports = class PushManifestPlugin {
+  constructor(env = {}) {
+    this.isESMBuild_ = env.esm;
+  }
 	apply(compiler) {
-		compiler.plugin('emit', function(compilation, callback) {
-      const manifest = createLoadManifest(compilation.assets);
+		compiler.plugin('emit', (compilation, callback) => {
+      const manifest = createLoadManifest(compilation.assets, this.isESMBuild_);
 
 			let output = JSON.stringify(manifest);
 			compilation.assets['push-manifest.json'] = {

--- a/packages/cli/lib/lib/webpack/push-manifest.js
+++ b/packages/cli/lib/lib/webpack/push-manifest.js
@@ -1,12 +1,12 @@
 const createLoadManifest = require('./create-load-manifest');
 
 module.exports = class PushManifestPlugin {
-  constructor(env = {}) {
-    this.isESMBuild_ = env.esm;
-  }
+	constructor(env = {}) {
+		this.isESMBuild_ = env.esm;
+	}
 	apply(compiler) {
 		compiler.plugin('emit', (compilation, callback) => {
-      const manifest = createLoadManifest(compilation.assets, this.isESMBuild_);
+			const manifest = createLoadManifest(compilation.assets, this.isESMBuild_);
 
 			let output = JSON.stringify(manifest);
 			compilation.assets['push-manifest.json'] = {

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -76,7 +76,7 @@ function clientConfig(env) {
 
 		plugins: [
 			...RenderHTMLPlugin(env),
-			new PushManifestPlugin(),
+			new PushManifestPlugin(env),
 			new CopyWebpackPlugin([
 				...(
 					existsSync(source('manifest.json'))

--- a/packages/cli/lib/resources/template.html
+++ b/packages/cli/lib/resources/template.html
@@ -11,9 +11,12 @@
 			<meta name="theme-color" content="<%= htmlWebpackPlugin.options.manifest.theme_color %>">
 		<% } %>
 		<% for (const file in htmlWebpackPlugin.options.createLoadManifest(compilation.assets)[htmlWebpackPlugin.options.url]) { %>
-			<% if (file) { %>
-				<link rel="preload" href="<%= htmlWebpackPlugin.files.publicPath + file %>" as="<%= file.match(/\.css$/)?'style':'script' %>" <%= file.match(/\.esm\.js$/)?'crossorigin="anonymous"':'' %>>
-			<% } %>
+      <% if (file && htmlWebpackPlugin.options.config.esm  && file.match(/\.(css|esm\.js)$/)) { %>
+        <!-- crossorigin for main bundle as that is loaded from <script type=module tag, other lazy loaded bundles are from webpack so its not needed -->
+				<link rel="preload" href="<%= htmlWebpackPlugin.files.publicPath + file %>" as="<%= file.match(/\.css$/)?'style':'script' %>" <%= file.match(/bundle\.\w{5}\.esm\.js$/)?'crossorigin="anonymous"':'' %>>
+      <% } else if (file && !htmlWebpackPlugin.options.config.esm && file.match(/\.(js|css)$/)) { %>
+        <link rel="preload" href="<%= htmlWebpackPlugin.files.publicPath + file %>" as="<%= file.match(/\.css$/)?'style':'script' %>" >
+      <% } %>
 		<% } %>
 		<% for (const file in compilation.assets) { %>
 			<% if (file.match(/manifest\.json$/)) { %>
@@ -28,7 +31,7 @@
 		<% if (webpack.assets.filter(entry => entry.name.match(/bundle.\w{5}.esm.js$/)).length > 0) { %>
 			<!-- Fix for safari < 11 nomodule bug. TODO: Do the following only for safari.-->
 			<script>!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()},!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();</script>
-			<script src="<%= htmlWebpackPlugin.files.publicPath %><%= webpack.assets.filter(entry => entry.name.match(/bundle.\w{5}.esm.js$/))[0].name %>" type="module"></script>
+			<script crossorigin="anonymous" src="<%= htmlWebpackPlugin.files.publicPath %><%= webpack.assets.filter(entry => entry.name.match(/bundle.\w{5}.esm.js$/))[0].name %>" type="module"></script>
 			<script nomodule defer src="<%= htmlWebpackPlugin.files.chunks['bundle'].entry %>"></script>
 			<!--
 				Fetch and Promise polyfills are not needed for browsers that support type=module

--- a/packages/cli/lib/resources/template.html
+++ b/packages/cli/lib/resources/template.html
@@ -11,12 +11,10 @@
 			<meta name="theme-color" content="<%= htmlWebpackPlugin.options.manifest.theme_color %>">
 		<% } %>
 		<% for (const file in htmlWebpackPlugin.options.createLoadManifest(compilation.assets)[htmlWebpackPlugin.options.url]) { %>
-      <% if (file && htmlWebpackPlugin.options.config.esm  && file.match(/\.(css|esm\.js)$/)) { %>
-        <!-- crossorigin for main bundle as that is loaded from <script type=module tag, other lazy loaded bundles are from webpack so its not needed -->
+			<% if (file && file.match(/\.(css|js)$/)) { %>
+				<!-- crossorigin for main bundle as that is loaded from <script type=module tag, other lazy loaded bundles are from webpack so its not needed -->
 				<link rel="preload" href="<%= htmlWebpackPlugin.files.publicPath + file %>" as="<%= file.match(/\.css$/)?'style':'script' %>" <%= file.match(/bundle\.\w{5}\.esm\.js$/)?'crossorigin="anonymous"':'' %>>
-      <% } else if (file && !htmlWebpackPlugin.options.config.esm && file.match(/\.(js|css)$/)) { %>
-        <link rel="preload" href="<%= htmlWebpackPlugin.files.publicPath + file %>" as="<%= file.match(/\.css$/)?'style':'script' %>" >
-      <% } %>
+			<% } %>
 		<% } %>
 		<% for (const file in compilation.assets) { %>
 			<% if (file.match(/manifest\.json$/)) { %>
@@ -30,7 +28,7 @@
 		}) %>
 		<% if (webpack.assets.filter(entry => entry.name.match(/bundle.\w{5}.esm.js$/)).length > 0) { %>
 			<!-- Fix for safari < 11 nomodule bug. TODO: Do the following only for safari.-->
-			<script>!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()},!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();</script>
+			<script defer>!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()},!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();</script>
 			<script crossorigin="anonymous" src="<%= htmlWebpackPlugin.files.publicPath %><%= webpack.assets.filter(entry => entry.name.match(/bundle.\w{5}.esm.js$/))[0].name %>" type="module"></script>
 			<script nomodule defer src="<%= htmlWebpackPlugin.files.chunks['bundle'].entry %>"></script>
 			<!--

--- a/packages/cli/lib/resources/template.html
+++ b/packages/cli/lib/resources/template.html
@@ -12,7 +12,7 @@
 		<% } %>
 		<% for (const file in htmlWebpackPlugin.options.createLoadManifest(compilation.assets)[htmlWebpackPlugin.options.url]) { %>
 			<% if (file) { %>
-				<link rel="preload" href="<%= htmlWebpackPlugin.files.publicPath + file %>">
+				<link rel="preload" href="<%= htmlWebpackPlugin.files.publicPath + file %>" as="<%= file.match(/\.css$/)?'style':'script' %>" <%= file.match(/\.esm\.js$/)?'crossorigin="anonymous"':'' %>>
 			<% } %>
 		<% } %>
 		<% for (const file in compilation.assets) { %>

--- a/packages/cli/lib/resources/template.html
+++ b/packages/cli/lib/resources/template.html
@@ -12,7 +12,7 @@
 		<% } %>
 		<% for (const file in htmlWebpackPlugin.options.createLoadManifest(compilation.assets, htmlWebpackPlugin.options.config.esm)[htmlWebpackPlugin.options.url]) { %>
 			<% if (file && file.match(/\.(css|js)$/)) { %>
-				<!-- crossorigin for main bundle as that is loaded from <script type=module tag, other lazy loaded bundles are from webpack so its not needed -->
+				<% /* crossorigin for main bundle as that is loaded from `<script type=module` tag, other lazy loaded bundles are from webpack so its not needed */ %>
 				<link rel="preload" href="<%= htmlWebpackPlugin.files.publicPath + file %>" as="<%= file.match(/\.css$/)?'style':'script' %>" <%= file.match(/bundle\.\w{5}\.esm\.js$/)?'crossorigin="anonymous"':'' %>>
 			<% } %>
 		<% } %>
@@ -27,14 +27,14 @@
 			url: '/'
 		}) %>
 		<% if (webpack.assets.filter(entry => entry.name.match(/bundle.\w{5}.esm.js$/)).length > 0) { %>
-			<!-- Fix for safari < 11 nomodule bug. TODO: Do the following only for safari.-->
+			<% /* Fix for safari < 11 nomodule bug. TODO: Do the following only for safari. */ %>
 			<script>!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()},!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();</script>
 			<script crossorigin="anonymous" src="<%= htmlWebpackPlugin.files.publicPath %><%= webpack.assets.filter(entry => entry.name.match(/bundle.\w{5}.esm.js$/))[0].name %>" type="module"></script>
 			<script nomodule defer src="<%= htmlWebpackPlugin.files.chunks['bundle'].entry %>"></script>
-			<!--
-				Fetch and Promise polyfills are not needed for browsers that support type=module
-				Please re-evaluate below line if adding more polyfills.
-			-->
+			<%
+				/*Fetch and Promise polyfills are not needed for browsers that support type=module
+				Please re-evaluate below line if adding more polyfills.*/
+			%>
 			<script nomodule>window.fetch||document.write('<script src="<%= htmlWebpackPlugin.files.chunks["polyfills"].entry %>"><\/script>')</script>
 		<% } else { %>
 			<script defer src="<%= htmlWebpackPlugin.files.chunks['bundle'].entry %>"></script>

--- a/packages/cli/lib/resources/template.html
+++ b/packages/cli/lib/resources/template.html
@@ -10,7 +10,7 @@
 		<% if (htmlWebpackPlugin.options.manifest.theme_color) { %>
 			<meta name="theme-color" content="<%= htmlWebpackPlugin.options.manifest.theme_color %>">
 		<% } %>
-		<% for (const file in htmlWebpackPlugin.options.createLoadManifest(compilation.assets)[htmlWebpackPlugin.options.url]) { %>
+		<% for (const file in htmlWebpackPlugin.options.createLoadManifest(compilation.assets, htmlWebpackPlugin.options.config.esm)[htmlWebpackPlugin.options.url]) { %>
 			<% if (file && file.match(/\.(css|js)$/)) { %>
 				<!-- crossorigin for main bundle as that is loaded from <script type=module tag, other lazy loaded bundles are from webpack so its not needed -->
 				<link rel="preload" href="<%= htmlWebpackPlugin.files.publicPath + file %>" as="<%= file.match(/\.css$/)?'style':'script' %>" <%= file.match(/bundle\.\w{5}\.esm\.js$/)?'crossorigin="anonymous"':'' %>>

--- a/packages/cli/tests/images/build.js
+++ b/packages/cli/tests/images/build.js
@@ -51,10 +51,10 @@ exports.prerender.heads.home = `
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<link rel="manifest" href="\\/manifest\\.json">
-	<link rel="preload" href="\\/bundle\\.\\w{5}\\.css">
-	<link rel="preload" href="\\/bundle\\.\\w{5}\\.js">
-	<link rel="preload" href="\\/route-home\\.chunk\\.\\w{5}\\.js">
-	<link rel="preload" href="\\/0\\.chunk\\.\\w{5}\\.css">
+	<link rel="preload" href="\\/bundle\\.\\w{5}\\.css" as="style">
+	<link rel="preload" href="\\/bundle\\.\\w{5}\\.js" as="script">
+	<link rel="preload" href="\\/route-home\\.chunk\\.\\w{5}\\.js" as="script">
+	<link rel="preload" href="\\/0\\.chunk\\.\\w{5}\\.css" as="style">
 	<link rel="shortcut icon" href="\\/favicon\\.ico">
 	<link href="\\/bundle\\.\\w{5}\\.css" rel="stylesheet">
 <\\/head>
@@ -68,10 +68,10 @@ exports.prerender.heads.route66 = `
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<link rel="manifest" href="\\/manifest\\.json">
-	<link rel="preload" href="\\/bundle\\.\\w{5}\\.css">
-	<link rel="preload" href="\\/bundle\\.\\w{5}\\.js">
-	<link rel="preload" href="\\/route-route66\\.chunk\\.\\w{5}\\.js">
-	<link rel="preload" href="\\/1\\.chunk\\.\\w{5}\\.css">
+	<link rel="preload" href="\\/bundle\\.\\w{5}\\.css" as="style">
+	<link rel="preload" href="\\/bundle\\.\\w{5}\\.js" as="script">
+	<link rel="preload" href="\\/route-route66\\.chunk\\.\\w{5}\\.js" as="script">
+	<link rel="preload" href="\\/1\\.chunk\\.\\w{5}\\.css" as="style">
 	<link rel="shortcut icon" href="\\/favicon\\.ico">
 	<link href="\\/bundle\\.\\w{5}\\.css" rel="stylesheet">
 <\\/head>


### PR DESCRIPTION
**Bugfix**

**Did you add tests for your changes?**
Yes.

**Summary**
- With the addition of `--esm` we need to push module bundle instead of regular ones.
I also cleaned `template.html` a bit.
- This also adds the needed `crossorigin` attribute to preload the module script.

**Does this PR introduce a breaking change?**
No.
