### PR TITLE
Fix SW registration

### DIFF
--- a/packages/cli/lib/lib/entry.js
+++ b/packages/cli/lib/lib/entry.js
@@ -6,7 +6,7 @@ if (process.env.NODE_ENV==='development') {
 }
 else if (process.env.ADD_SW && 'serviceWorker' in navigator) {
 	// eslint-disable-next-line no-undef
-	navigator.serviceWorker.register(__webpack_public_path__ + process.env.ES_BUILD? 'sw-esm.js' : 'sw.js');
+	navigator.serviceWorker.register(__webpack_public_path__ + (process.env.ES_BUILD ? 'sw-esm.js' : 'sw.js'));
 }
 
 const interopDefault = m => m && m.default ? m.default : m;

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -109,8 +109,8 @@ function isProd(config) {
 		plugins: [
 			new webpack.DefinePlugin({
 				'process.env.ADD_SW': config.sw,
-				'process.env.ESM': config.esm,
 				'process.env.ES_BUILD': false,
+				'process.env.ESM': config.esm,
 			})
 		],
 
@@ -201,6 +201,7 @@ function isProd(config) {
 				},
 			}),
 		);
+
 		if (config.sw) {
 			prodConfig.plugins.push(
 				new SWPrecacheWebpackPlugin({


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix, Closes #622 


**Summary**

The previous code was producing this within `preact build` output:

```js
navigator.serviceWorker.register(n.p+!1?"sw-esm.js":"sw.js")
```

It is now this:

```js
navigator.serviceWorker.register(n.p+"sw.js");
```

