### PR TITLE
Inline PRERENDER=true env var during prerendering

### DIFF
--- a/src/lib/webpack/webpack-base-config.js
+++ b/src/lib/webpack/webpack-base-config.js
@@ -204,7 +204,8 @@ export default function (env) {
 		plugins: [
 			new webpack.NoEmitOnErrorsPlugin(),
 			new webpack.DefinePlugin({
-				'process.env.NODE_ENV': JSON.stringify(isProd ? 'production' : 'development')
+				'process.env.NODE_ENV': JSON.stringify(isProd ? 'production' : 'development'),
+				'PRERENDER': env.ssr ? 'true' : 'false'
 			}),
 			// Extract CSS
 			new ExtractTextPlugin({

--- a/src/lib/webpack/webpack-server-config.js
+++ b/src/lib/webpack/webpack-server-config.js
@@ -24,6 +24,7 @@ function serverConfig(env) {
 }
 
 export default function (env) {
+	env = Object.assign({}, env, { ssr: true });
 	return merge(
 		baseConfig(env),
 		serverConfig(env)


### PR DESCRIPTION
Makes a `PRERENDER` env var defined that indicates whether the bundle was compiled for prerendering or client-side usage.  This is useful for avoiding SSR-specific code ending up in client bundles.