### PR TITLE
Fix Tests

### DIFF
--- a/packages/cli/tests/images/create.js
+++ b/packages/cli/tests/images/create.js
@@ -1,10 +1,10 @@
 const path = require('path');
 
 exports.default = [
+	'.babelrc',
 	'.gitignore',
 	'package.json',
 	'README.md',
-	'src/.babelrc',
 	'src/assets/favicon.ico',
 	'src/assets/icons/android-chrome-192x192.png',
 	'src/assets/icons/android-chrome-512x512.png',
@@ -22,8 +22,8 @@ exports.default = [
 	'src/routes/profile/index.js',
 	'src/routes/profile/style.css',
 	'src/style/index.css',
-	'src/tests/__mocks__/browserMocks.js',
-	'src/tests/__mocks__/fileMocks.js',
-	'src/tests/header.test.js'
+	'tests/__mocks__/browserMocks.js',
+	'tests/__mocks__/fileMocks.js',
+	'tests/header.test.js'
 ].map(s => s.replace(/\//g, path.sep));
 

--- a/packages/cli/tests/images/create.js
+++ b/packages/cli/tests/images/create.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 exports.default = [
-	'.babelrc',
+	// '.babelrc',
 	'.gitignore',
 	'package.json',
 	'README.md',

--- a/packages/cli/tests/lib/cli.js
+++ b/packages/cli/tests/lib/cli.js
@@ -1,7 +1,8 @@
-const mkdirp = require('mkdirp');
 const { join } = require('path');
+const { existsSync, unlinkSync } = require('fs');
 const cmd = require('../../lib/commands');
 const { tmpDir } = require('./output');
+const mkdirp = require('mkdirp');
 
 const argv = {
 	_: [],
@@ -14,7 +15,15 @@ const argv = {
 exports.create = async function (template, name) {
 	let dest = tmpDir();
 	name = name || `test-${template}`;
+
 	await cmd.create(template, dest, { name, cwd:'.' });
+
+	// TODO: temporary – will resolve after 2.x->3.x release
+	// Templates are using 2.x, which needs `.babelrc` for TEST modification.
+	// The 3.x templates won't need `.babelrc` for { modules: commonjs }
+	let babelrc = join(dest, '.babelrc');
+	existsSync(babelrc) && unlinkSync(babelrc);
+
 	return dest;
 };
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fix

**Did you add tests for your changes?**

meta

**Summary**

The tests are scaffolding the `default` template which relies on `preact-cli@2.x`, which _requires_ that there be a `.babelrc` file to handle `NODE_ENV`-dependent `modules` formatting. 

> The `.babelrc` file itself was also broken. See https://github.com/preactjs-templates/default/pull/21.<br>^ Not required for this PR.

The current `preact-cli/babel` (and #639) will respond to a `test` environment automatically, so there'll be no need to ship a `.babelrc` file.

The `Cannot find module "preact-cli/babel"` was thrown in testing because we use `--cwd` while building the test directories (for performance / to avoid `npm install` xN). When this happens, dependency lookups are done from the root directory.

Well, the _root directory_ doesn't have `preact-cli` as `devDependency` ... only the test directory does. Because of that, the process can't find a module named `"preact-cli"`; let alone a entry file within it.

**Does this PR introduce a breaking change?**

No

