### PR TITLE
fix: include terser-webpack-plugin as dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,8 +43,7 @@
     "node-sass": "^4.9.0",
     "p-retry": "^2.0.0",
     "puppeteer": "^1.3.0",
-    "sass-loader": "^7.0.1",
-    "terser-webpack-plugin": "^1.1.0"
+    "sass-loader": "^7.0.1"
   },
   "dependencies": {
     "@babel/core": "^7.0.0-beta.51",
@@ -107,6 +106,7 @@
     "stack-trace": "0.0.10",
     "style-loader": "^0.21.0",
     "sw-precache-webpack-plugin": "^0.11.2",
+    "terser-webpack-plugin": "^1.1.0",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "unfetch": "^3.0.0",
     "update-notifier": "^2.5.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

dependency bugfix

**Did you add tests for your changes?**

no

**Summary**

was trying the _next_ branch, but was failing without locally installing this module.

**Does this PR introduce a breaking change?**

_nope_

**Other information**


Node: `v8.10.0`
npm: `yarn@1.9.4`
CLI: `preact-cli@3.0.0-next.13`
operating system: `macOS`
browser: `N/A`


```
$ preact build
module.js:549
    throw err;
    ^

Error: Cannot find module 'terser-webpack-plugin'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/redacted/node_modules/preact-cli/lib/lib/webpack/webpack-client-config.js:8:22)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/redacted/node_modules/preact-cli/lib/lib/webpack/run-webpack.js:9:22)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
error Command failed with exit code 1.
```
