### PR TITLE
remove script-ext-html-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "raw-loader": "^0.5.1",
     "require-relative": "^0.8.7",
     "rimraf": "^2.6.1",
-    "script-ext-html-webpack-plugin": "^1.8.0",
     "simplehttp2server": "^2.0.0",
     "source-map": "^0.5.6",
     "stack-trace": "0.0.10",

--- a/src/lib/webpack/render-html-plugin.js
+++ b/src/lib/webpack/render-html-plugin.js
@@ -1,7 +1,6 @@
 import { resolve } from 'path';
 import { existsSync } from 'fs';
 import HtmlWebpackExcludeAssetsPlugin from 'html-webpack-exclude-assets-plugin';
-import ScriptExtHtmlWebpackPlugin from 'script-ext-html-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { readJson } from './webpack-base-config';
 import prerender from './prerender';
@@ -31,17 +30,14 @@ export default function (config) {
 			config,
 			ssr(params) {
 				return config.prerender ? prerender({ cwd, dest, src }, { ...params, url }) : '';
-			}
+			},
+			scriptLoading: 'defer'
 		});
 	};
 
 	const pages = readJson(resolve(cwd, config.prerenderUrls || '')) || [{ url: '/' }];
 
 	return pages.map(htmlWebpackConfig).map(conf => new HtmlWebpackPlugin(conf)).concat([
-		new HtmlWebpackExcludeAssetsPlugin(),
-		new ScriptExtHtmlWebpackPlugin({
-			// inline: 'bundle.js',
-			defaultAttribute: 'defer'
-		})
+		new HtmlWebpackExcludeAssetsPlugin()
 	]);
 }

--- a/src/resources/template.html
+++ b/src/resources/template.html
@@ -25,7 +25,7 @@
 		<%= htmlWebpackPlugin.options.ssr({
 			url: '/'
 		}) %>
-		<script defer src="<%= htmlWebpackPlugin.files.chunks['bundle'].entry %>"></script>
+		<script <%= htmlWebpackPlugin.options.scriptLoading %> src="<%= htmlWebpackPlugin.files.chunks['bundle'].entry %>"></script>
 		<script>window.fetch||document.write('<script src="<%= htmlWebpackPlugin.files.chunks["polyfills"].entry %>"><\/script>')</script>
 	</body>
 </html>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Refactoring

**Did you add tests for your changes?**

No

**Summary**

After this fix https://github.com/developit/preact-cli/pull/127 script tag is added by template instead of using `script-ext-html-webpack-plugin`. Also the `defaultAttribute` is not used as it is hardcoded in template.

I propose adding a new option in `html-webpack-plugin` called `scriptLoading` and it is configurable.


**Does this PR introduce a breaking change?**

NO
