### PR TITLE
Addresses issue #679 by replacing `[id]` with `[name]` for the `chunkFilename` in `MiniCssExtractPlugin`

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -203,7 +203,7 @@ module.exports = function (env) {
 			// Extract CSS
 			new MiniCssExtractPlugin({
 				filename: isProd ? "[name].[contenthash:5].css" : "[name].css",
-				chunkFilename: isProd ? "[id].chunk.[contenthash:5].css" : "[id].chunk.css"
+				chunkFilename: isProd ? "[name].chunk.[contenthash:5].css" : "[name].chunk.css"
 			}),
 			new ProgressBarPlugin({
 				format: '\u001b[90m\u001b[44mBuild\u001b[49m\u001b[39m [:bar] \u001b[32m\u001b[1m:percent\u001b[22m\u001b[39m (:elapseds) \u001b[2m:msg\u001b[22m',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix - adjusts how css chunk files are named

**Did you add tests for your changes?**
No

**Summary**
Per issue #679 - the `MiniCssExtractPlugin` names files numerically with `[id]` rather than using `[name]`

**Does this PR introduce a breaking change?**
It shouldn't

**Other information**

`preact-cli@3.0.0-next.14`