### PR TITLE
Upgrade url-loader version

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "tmp": "0.0.31",
     "unfetch": "^3.0.0",
     "update-notifier": "^2.3.0",
-    "url-loader": "^0.5.8",
+    "url-loader": "^0.6.2",
     "validate-npm-package-name": "^3.0.0",
     "webpack": "^3.7.0",
     "webpack-dev-server": "^2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4849,13 +4849,13 @@ mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, 
   dependencies:
     mime-db "~1.30.0"
 
-mime@1.3.x:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
-
 mime@1.4.1, mime@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
+
+mime@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -7259,12 +7259,13 @@ urijs@^1.16.1:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.0.tgz#d8aa284d0e7469703a6988ad045c4cbfdf08ada0"
 
-url-loader@^0.5.8:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-0.5.9.tgz#cc8fea82c7b906e7777019250869e569e995c295"
+url-loader@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-0.6.2.tgz#a007a7109620e9d988d14bce677a1decb9a993f7"
   dependencies:
     loader-utils "^1.0.2"
-    mime "1.3.x"
+    mime "^1.4.1"
+    schema-utils "^0.3.0"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Upgrades the package `url-loader` to the most recent version that does not involve a major version change.

**Did you add tests for your changes?**

No

**Summary**

This avoids a vulnerability with package mime version < 1.4.1

See here for details https://nvd.nist.gov/vuln/detail/CVE-2017-16138

**Does this PR introduce a breaking change?**

I don't think so.

**Other information**

`url-loader@0.5.8` dependes on `mime@1.3.x`, which is vulnerable.

This PR upgrades to `url-loader@0.6.2`, which in turn depends on the more recent `mime@1.4.1`, not vulnerable.