### PR TITLE
[SW] Don't invoke skipWaiting

### DIFF
--- a/src/lib/webpack/webpack-client-config.js
+++ b/src/lib/webpack/webpack-client-config.js
@@ -152,6 +152,7 @@ function isProd(config) {
 				navigateFallback: 'index.html',
 				navigateFallbackWhitelist: [/^(?!\/__).*/],
 				minify: true,
+				skipWaiting: false,
 				stripPrefix: config.cwd,
 				staticFileGlobsIgnorePatterns: [
 					/polyfills(\..*)?\.js$/,


### PR DESCRIPTION
This fixes the issue where lazy-loaded splitted chunks fail because the SW has been updated and the previous URLs are now 404's.

Docs: https://github.com/GoogleChromeLabs/sw-precache#skipwaiting-boolean