### PR TITLE
Allow prerenderUrls to be a javascript file

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,10 +231,24 @@ The format required for defining your routes is an array of objects with a `url`
 ];
 ```
 
-You can customise the path of `prerender-urls.json` by using the flag `--prerenderUrls`.
+You can customise the path and/or name of `prerender-urls.json` by using the flag `--prerenderUrls`.
 
 ```sh
 preact build --prerenderUrls src/prerender-urls.json
+```
+
+If a static JSON file is too restrictive, you may want to provide a javascript file that exports your routes instead.
+Routes can be exported as a JSON string or an object and can optionally be returned from a function.
+
+```js
+// prerender-urls.js
+module.exports = [{
+	url: '/',
+	title: 'Homepage'
+}, {
+	url: '/route/random'
+}];
+
 ```
 
 #### Template

--- a/packages/cli/lib/lib/webpack/render-html-plugin.js
+++ b/packages/cli/lib/lib/webpack/render-html-plugin.js
@@ -72,7 +72,7 @@ module.exports = function(config) {
 				pages = result;
 			}
 		} catch (error) {
-			warn(error.message);
+			warn(`Failed to load prerenderUrls file, using default!\n${error.stack}`);
 		}
 	}
 

--- a/packages/cli/lib/lib/webpack/render-html-plugin.js
+++ b/packages/cli/lib/lib/webpack/render-html-plugin.js
@@ -6,6 +6,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const prerender = require('./prerender');
 const createLoadManifest = require('./create-load-manifest');
 const template = resolve(__dirname, '../../resources/template.html');
+const { warn } = require('../../util');
 
 module.exports = function(config) {
 	const { cwd, dest, isProd, src } = config;
@@ -71,7 +72,7 @@ module.exports = function(config) {
 				pages = result;
 			}
 		} catch (error) {
-			console.error(error);
+			warn(error.message);
 		}
 	}
 

--- a/packages/cli/lib/lib/webpack/render-html-plugin.js
+++ b/packages/cli/lib/lib/webpack/render-html-plugin.js
@@ -54,9 +54,21 @@ module.exports = function(config) {
 		});
 	};
 
-	const pages = readJson(resolve(cwd, config.prerenderUrls || '')) || [
-		{ url: '/' },
-	];
+	let pages;
+	const {prerenderUrls} = config;
+
+	if (!prerenderUrls) {
+		pages = [{ url: '/' }];
+	} else if (/\.json$/i.test(prerenderUrls)) {
+		pages = readJson(resolve(cwd, prerenderUrls));
+	} else if (/\.js$/i.test(prerenderUrls)) {
+		let result = require(resolve(cwd, prerenderUrls));
+		result = result.default ? result.default : result;
+		if (typeof result === 'function') {
+			result = result();
+		}
+		pages = typeof result === 'string' ? JSON.parse(result) : result;
+	}
 
 	return pages
 		.map(htmlWebpackConfig)

--- a/packages/cli/lib/lib/webpack/render-html-plugin.js
+++ b/packages/cli/lib/lib/webpack/render-html-plugin.js
@@ -70,7 +70,9 @@ module.exports = function(config) {
 			if (result instanceof Array) {
 				pages = result;
 			}
-		} catch (ignored) {}
+		} catch (error) {
+			console.error(error);
+		}
 	}
 
 	return pages


### PR DESCRIPTION
**What kind of change does this PR introduce?**
An improvement to an existing feature for the build steps.

**Did you add tests for your changes?**
No, I could not find any tests related to the `prerenderUrls` option so I'm not sure how you want to handle this.

**Summary**
See #692 for more details, but in short this change allows for greater flexibility and more dynamic route building.

**Does this PR introduce a breaking change?**
No.

**List of supported formats for prerenderUrls**
* JSON file (unchanged)

* JS file with `module.exports = [{url: '/'}, ...]`
* JS file with `export default [{url: '/'}, ...]`

* JS file with `module.exports = () => [{url: '/'}, ...]`
* JS file with `export default () => [{url: '/'}, ...]`

* JS file with `module.exports = '"[{"url":"/"}, ...]"'`
* JS file with `export default '"[{"url":"/"}, ...]"'`

* JS file with `module.exports = () => '"[{"url":"/"}, ...]"'`
* JS file with `export default () => '"[{"url":"/"}, ...]"'`

**Promises and async functions**
These take a bit more to support, so I kept it small for this pull request. Support can always be improved later.