### PR TITLE
Silence DeprecationWarning

### DIFF
--- a/packages/cli/lib/lib/output-hooks.js
+++ b/packages/cli/lib/lib/output-hooks.js
@@ -3,11 +3,19 @@ const HOOKS = [
 		test: /^total precache size /i,
 		handler: text => `\n  \u001b[32m${text}\u001b[39m`,
 	},
+	{
+		test: /DeprecationWarning/,
+		handler: () => false
+	}
 ];
 
 function wrap(stream, handler) {
 	let write = stream.write;
-	stream.write = text => write.call(stream, handler(text));
+	stream.write = text => {
+		const transformed = handler(text);
+		if (transformed === false) return;
+		return write.call(stream, transformed);
+	};
 	return () => {
 		stream.write = write;
 	};


### PR DESCRIPTION
A DeprecationWarning message from some plugin (not sure which) breaks our nice progress meter and looks bad. This turns it off.