### PR TITLE
Add missing options to `preact watch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ $ preact watch
   --cwd         A directory to use instead of $PWD.              [string]   [default: .]
   --src         Entry file (index.js)                            [string]   [default: "src"]
   --port, -p    Port to start a server on                        [string]   [default: "8080"]
-  --host,       Hostname to start a server on                    [string]   [default: "0.0.0.0"]
+  --host, -H    Hostname to start a server on                    [string]   [default: "0.0.0.0"]
   --https       Use HTTPS?                                       [boolean]  [default: false]
   --prerender   Pre-render static app content on initial build   [boolean]  [default: false]
+  --template    Path to template used by webpack                 [string]   [default: none]
+  --config, c   Path to custom preact.config.js                  [string]   [default: none]
 ```
 
 Note:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Documentation improvement

**Did you add tests for your changes?**

n/a

**Summary**

The README currently doesn't include the documentation for `--template` and `--config` options for `preact watch`, so here they are. I've also added the missing short-form for `--host`.

**Does this PR introduce a breaking change?**

n/a

**Other information**

n/a
