### PR TITLE
Next: Fix TypeScript support for automatic code splitting

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -56,10 +56,10 @@ function clientConfig(env) {
 		module: {
 			rules: [
 				{
-					test: /\.jsx?$/,
+					test: /\.[jt]sx?$/,
 					include: [
-						filter(source('routes') + '/{*.js,*/index.js}'),
-						filter(source('components') + '/{routes,async}/{*.js,*/index.js}'),
+						filter(source('routes') + '/{*,*/index}.{js,jsx,ts,tsx}'),
+						filter(source('components') + '/{routes,async}/{*,*/index}.{js,jsx,ts,tsx}'),
 					],
 					loader: require.resolve('@preact/async-loader'),
 					options: {


### PR DESCRIPTION
This fixes automatic code splitting when routes are `.ts` or `.tsx` files.