### PR TITLE
[next] fix keyframe name collisisions

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -205,7 +205,12 @@ function isProd(config) {
 					},
 					sourceMap: true,
 				}),
-				new OptimizeCssAssetsPlugin({}),
+				new OptimizeCssAssetsPlugin({
+					cssProcessorOptions: {
+						// Fix keyframes in different CSS chunks minifying to colliding names:
+						reduceIdents: false
+					}
+				}),
 			],
 		},
 	};


### PR DESCRIPTION
This fixes `@keyframes` rules from multiple CSS chunks being minified to the same name (generally "a" or "b"). Currently, `optimize-css-assets-webpack-plugin` does not have a way to minify global identifiers across assets without colliding.
