### PR TITLE
correcting `sass-loader` `options.includePaths`

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -148,7 +148,7 @@ module.exports = function(env) {
 								loader: 'sass-loader',
 								options: {
 									sourceMap: true,
-									includePaths: [nodeModules],
+									includePaths: [...nodeModules],
 								},
 							},
 						},


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix: the `sass-loader` `options.includePaths` need to be an array of strings rather than containing a element which is an array of strings

**Did you add tests for your changes?**

No

**Summary**

The `sass-loader` was not able to resolve sass from `@material` in `node_modules.



**Does this PR introduce a breaking change?**

Not that I know of

**Other information**

<!-- Node version, npm version, CLI version, operating system, browser -->
