### PR TITLE
Add FixStyleOnlyEntriesPlugin

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -6,6 +6,7 @@ const SizePlugin = require('size-plugin');
 const autoprefixer = require('autoprefixer');
 const requireRelative = require('require-relative');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
 const ProgressBarPlugin = require('progress-bar-webpack-plugin');
 const ReplacePlugin = require('webpack-plugin-replace');
 const createBabelConfig = require('../babel-config');
@@ -237,6 +238,8 @@ module.exports = function(env) {
 			new webpack.ProvidePlugin({
 				h: ['preact', 'h'],
 			}),
+			// Fix for https://github.com/webpack-contrib/mini-css-extract-plugin/issues/151
+			new FixStyleOnlyEntriesPlugin(),
 			// Extract CSS
 			new MiniCssExtractPlugin({
 				filename: isProd ? '[name].[contenthash:5].css' : '[name].css',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -119,6 +119,7 @@
     "webpack": "^4.6.0",
     "webpack-bundle-analyzer": "^2.11.3",
     "webpack-dev-server": "^3.1.3",
+    "webpack-fix-style-only-entries": "^0.2.0",
     "webpack-merge": "^4.1.0",
     "webpack-plugin-replace": "^1.2.0",
     "which": "^1.2.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11915,6 +11915,11 @@ webpack-dev-server@^3.1.3:
     webpack-log "^2.0.0"
     yargs "12.0.2"
 
+webpack-fix-style-only-entries@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-fix-style-only-entries/-/webpack-fix-style-only-entries-0.2.0.tgz#87b11a0eee21c2fe6191a50d478d69eb70815957"
+  integrity sha512-3EKneRqg1NI5iQro9tFq3W0hYNu7iH2ZvTB7CbTQMUymsouZZd1elsDIYh8KUqCQj7O+/QySepHM80FcWi4O0Q==
+
 webpack-log@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-2.0.0.tgz#5b7928e0637593f119d32f6227c1e0ac31e1b47f"


### PR DESCRIPTION
Add [FixStyleOnlyEntriesPlugin](https://github.com/fqborges/webpack-fix-style-only-entries#webpack-fix-style-only-entries) to remove empty .js files created for CSS assets.

Currently, non-initial CSS chunks always generate corresponding JS chunks that are "empty" from webpack's perspective (a module registry with one empty module).