### PR TITLE
Allow async prerender urls

### DIFF
--- a/packages/cli/lib/lib/webpack/render-html-plugin.js
+++ b/packages/cli/lib/lib/webpack/render-html-plugin.js
@@ -5,9 +5,11 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const prerender = require('./prerender');
 const createLoadManifest = require('./create-load-manifest');
 const { warn } = require('../../util');
+const { yellow } = require('kleur');
+
 let template = resolve(__dirname, '../../resources/template.html');
 
-module.exports = function(config) {
+module.exports = async function(config) {
 	const { cwd, dest, isProd, src } = config;
 	const inProjectTemplatePath = resolve(cwd, dest, '../template.html');
 	if (existsSync(inProjectTemplatePath)) {
@@ -66,7 +68,9 @@ module.exports = function(config) {
 					result = result.default();
 				}
 				if (typeof result === 'function') {
-					result = result();
+					console.log(yellow(`Fetching URLs from ${config.prerenderUrls}`));
+					result = await result();
+					console.log(yellow(`Fetched URLs from ${config.prerenderUrls}`));
 				}
 				if (typeof result === 'string') {
 					result = JSON.parse(result);

--- a/packages/cli/lib/lib/webpack/render-html-plugin.js
+++ b/packages/cli/lib/lib/webpack/render-html-plugin.js
@@ -5,8 +5,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const prerender = require('./prerender');
 const createLoadManifest = require('./create-load-manifest');
 const { warn } = require('../../util');
-const { yellow } = require('kleur');
-
+const { info } = require('../../util');
 let template = resolve(__dirname, '../../resources/template.html');
 
 module.exports = async function(config) {
@@ -68,9 +67,9 @@ module.exports = async function(config) {
 					result = result.default();
 				}
 				if (typeof result === 'function') {
-					console.log(yellow(`Fetching URLs from ${config.prerenderUrls}`));
+					info(`Fetching URLs from ${config.prerenderUrls}`);
 					result = await result();
-					console.log(yellow(`Fetched URLs from ${config.prerenderUrls}`));
+					info(`Fetched URLs from ${config.prerenderUrls}`);
 				}
 				if (typeof result === 'string') {
 					result = JSON.parse(result);

--- a/packages/cli/lib/lib/webpack/run-webpack.js
+++ b/packages/cli/lib/lib/webpack/run-webpack.js
@@ -12,7 +12,7 @@ const transformConfig = require('./transform-config');
 const { error, isDir, warn } = require('../../util');
 
 async function devBuild(env) {
-	let config = clientConfig(env);
+	let config = await clientConfig(env);
 
 	await transformConfig(env, config);
 
@@ -81,7 +81,7 @@ async function devBuild(env) {
 }
 
 async function prodBuild(env) {
-	let config = clientConfig(env);
+	let config = await clientConfig(env);
 	await transformConfig(env, config);
 
 	if (env.prerender) {

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -21,7 +21,7 @@ const cleanFilename = name =>
 		''
 	);
 
-function clientConfig(env) {
+async function clientConfig(env) {
 	const { isProd, source, src /*, port? */ } = env;
 
 	let entry = {
@@ -84,7 +84,7 @@ function clientConfig(env) {
 
 		plugins: [
 			new PushManifestPlugin(env),
-			...RenderHTMLPlugin(env),
+			...(await RenderHTMLPlugin(env)),
 			...getBabelEsmPlugin(env),
 			new CopyWebpackPlugin(
 				[
@@ -208,8 +208,8 @@ function isProd(config) {
 				new OptimizeCssAssetsPlugin({
 					cssProcessorOptions: {
 						// Fix keyframes in different CSS chunks minifying to colliding names:
-						reduceIdents: false
-					}
+						reduceIdents: false,
+					},
 				}),
 			],
 		},
@@ -304,10 +304,10 @@ function isDev(config) {
 	};
 }
 
-module.exports = function(env) {
+module.exports = async function(env) {
 	return merge(
 		baseConfig(env),
-		clientConfig(env),
+		await clientConfig(env),
 		(env.isProd ? isProd : isDev)(env)
 	);
 };

--- a/packages/cli/tests/build.test.js
+++ b/packages/cli/tests/build.test.js
@@ -10,7 +10,11 @@ const images = require('./images/build');
 // const ours = ['empty', 'full', 'simple', 'root'];
 const ours = ['default'];
 
-const prerenderUrlFiles = ['prerender-urls.json', 'prerender-urls.js'];
+const prerenderUrlFiles = [
+	'prerender-urls.json',
+	'prerender-urls.js',
+	'prerender-urls.promise.js',
+];
 
 async function getIndex(dir, file = 'index.html') {
 	file = join(dir, `build/${file}`);

--- a/packages/cli/tests/subjects/multiple-prerendering/prerender-urls.promise.js
+++ b/packages/cli/tests/subjects/multiple-prerendering/prerender-urls.promise.js
@@ -1,0 +1,17 @@
+const data = [
+	{
+		url: '/',
+		title: 'Home',
+	},
+	{
+		url: '/route66',
+		title: 'Route66',
+	},
+	{
+		url: '/custom',
+		title: 'Custom',
+		myProp: 'It worked!',
+	},
+];
+
+module.exports = () => new Promise(resolve => resolve(data));


### PR DESCRIPTION
**What kind of change does this PR introduce?**

It allows prerender-urls.js to return a promise

**Did you add tests for your changes?**

Yes

**Summary**
Currently `prerender-urls.js` can return a function but only sync. This allows that function to be async as well. Allowing `preact-cli` to be a static site generator

**Does this PR introduce a breaking change?**
No
