### PR TITLE
Do not force a favicon

### DIFF
--- a/packages/cli/lib/lib/webpack/render-html-plugin.js
+++ b/packages/cli/lib/lib/webpack/render-html-plugin.js
@@ -28,7 +28,7 @@ module.exports = async function(config) {
 			},
 			favicon: existsSync(resolve(src, 'assets/favicon.ico'))
 				? 'assets/favicon.ico'
-				: resolve(__dirname, '../../resources/favicon.ico'),
+				: '',
 			inject: true,
 			compile: true,
 			inlineCss: config['inline-css'],

--- a/packages/cli/tests/images/build.js
+++ b/packages/cli/tests/images/build.js
@@ -1,16 +1,12 @@
 const common = {
 	'polyfills.*.js': 4620,
 	'polyfills.*.js.map': 31760,
-	'favicon.ico': 15086,
 };
 
 exports.default = exports.full = Object.assign({}, common, {
-	'assets/favicon.ico': 15086,
 	'assets/icons/android-chrome-192x192.png': 14058,
 	'assets/icons/android-chrome-512x512.png': 51484,
 	'assets/icons/apple-touch-icon.png': 12746,
-	'assets/icons/favicon-16x16.png': 626,
-	'assets/icons/favicon-32x32.png': 1487,
 	'assets/icons/mstile-150x150.png': 9050,
 	'push-manifest.json': 327,
 	'manifest.json': 426,
@@ -51,7 +47,6 @@ exports.prerender.heads.home = `
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<link rel="manifest" href="\\/manifest\\.json">
-	<link rel="shortcut icon" href="\\/favicon\\.ico">
 	<link href=\\"/bundle.\\w{5}.css\\" rel=\\"preload\\" as=\\"style\\">
 	<style>html{padding:0;}<\\/style>
 <\\/head>
@@ -65,7 +60,6 @@ exports.prerender.heads.route66 = `
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<link rel="manifest" href="\\/manifest\\.json">
-	<link rel="shortcut icon" href="\\/favicon\\.ico">
 	<link href=\\"/bundle.\\w{5}.css\\" rel=\\"preload\\" as=\\"style\\">
 	<style>html{padding:0;}<\\/style>
 <\\/head>
@@ -79,7 +73,6 @@ exports.prerender.heads.custom = `
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<link rel="manifest" href="\\/manifest\\.json">
-	<link rel="shortcut icon" href="\\/favicon\\.ico">
 	<link href=\\"/bundle.\\w{5}.css\\" rel=\\"preload\\" as=\\"style\\">
 	<style>html{padding:0;}<\\/style>
 <\\/head>
@@ -99,7 +92,6 @@ exports.preload.head = `
 	<link rel=\\"preload\\" href=\\"\\/route-home\\.chunk\\.\\w{5}\\.js\\" as=\\"script\\">
 	<link rel=\\"preload\\" href=\\"\\/route-home\\~route-route66\\~route-route89\\.chunk\\.\\w{5}\\.js\\" as=\\"script\\">
 	<link rel=\\"preload\\" href=\\"\\/route-home\\.chunk\\.\\w{5}\\.css\\" as=\\"style\\">
-	<link rel=\\"shortcut icon\\" href=\\"\\/favicon\\.ico\\">
 	<link href=\\"\\/bundle\\.\\w{5}\\.css\\" rel=\\"preload\\" as=\\"style\\">
 	<style>html{padding:0;}<\\/style>
 </head>
@@ -138,7 +130,6 @@ exports.webpack = `
 	<head>
 		<meta charset="utf-8">
 		<title>preact-webpack</title>
-		<link rel="shortcut icon" href="/favicon.ico"></link>
 	</head>
 	<body>
 		<h1>Guess what</h1>
@@ -154,7 +145,6 @@ exports.template = `
 	<head>
 		<meta charset="utf-8">
 		<title>Custom title</title>
-		<link rel="shortcut icon" href="/favicon.ico"></link>
 	</head>
 	<body>
 		<h1>Guess what</h1>


### PR DESCRIPTION
This PR removes the default/fallback favicon. (https://github.com/developit/preact-cli/issues/643)

The specs are updated to reflect the no-icon-by-default markup. This could be improved, as the case where an asset _does_ exist is no longer covered by the specs.