### PR TITLE
Make 'Installing Dependencies' stage of app creation more verbose

### DIFF
--- a/packages/cli/lib/lib/setup.js
+++ b/packages/cli/lib/lib/setup.js
@@ -5,7 +5,7 @@ const stdio = 'ignore';
 
 exports.install = function(cwd, isYarn) {
 	let cmd = isYarn ? 'yarn' : 'npm';
-	return spawn(cmd, ['install'], { cwd, stdio });
+	return spawn(cmd, ['install'], { cwd, stdio: 'inherit' });
 };
 
 exports.addScripts = async function(obj, cwd, isYarn) {


### PR DESCRIPTION
This PR makes the 'Installing Dependencies' stage of creating a new app more verbose. (https://github.com/developit/preact-cli/issues/684)