### PR TITLE
Fix weird highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ preact build
   --prerenderUrls      Path to pre-render routes configuration.   [string]   [default: "prerender-urls.json"]
   --template           Path to template file.                     [string]   [default: none]
   --service-worker     Add a service worker to application.       [boolean]  [default: true]
-  --no-service-worker  Dont create a service worker at all.      [boolean]  [default: false]
+  --no-service-worker  Dont create a service worker at all.       [boolean]  [default: false]
   --production, -p     Create a minified production build.        [boolean]  [default: true]
   --no-prerender       Disable pre-render of static app content.  [boolean]  [default: false]
   --clean              Clear output directory before building.    [boolean]  [default: true]

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ preact build
   --prerenderUrls      Path to pre-render routes configuration.   [string]   [default: "prerender-urls.json"]
   --template           Path to template file.                     [string]   [default: none]
   --service-worker     Add a service worker to application.       [boolean]  [default: true]
-  --no-service-worker  Don't create a service worker at all.      [boolean]  [default: false]
+  --no-service-worker  Dont create a service worker at all.      [boolean]  [default: false]
   --production, -p     Create a minified production build.        [boolean]  [default: true]
   --no-prerender       Disable pre-render of static app content.  [boolean]  [default: false]
   --clean              Clear output directory before building.    [boolean]  [default: true]


### PR DESCRIPTION
Looks like a `'` in the README was adding highlighting we don't want.

__Before:__
![](https://user-images.githubusercontent.com/2591901/56078803-0e93ba80-5de4-11e9-9bf9-3ec575761a2a.png)

__After:__
![](https://user-images.githubusercontent.com/2591901/56078790-fd4aae00-5de3-11e9-8e9e-9f0ee2c30743.png)
