### PR TITLE
Added .wasm extension to base webpack config for support of importing .wasm files

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -101,6 +101,7 @@ module.exports = function(env) {
 				'.sass',
 				'.styl',
 				'.css',
+        '.wasm',
 			],
 			alias: {
 				style: source('style'),

--- a/packages/cli/lib/lib/webpack/webpack-base-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-base-config.js
@@ -101,7 +101,7 @@ module.exports = function(env) {
 				'.sass',
 				'.styl',
 				'.css',
-        '.wasm',
+				'.wasm',
 			],
 			alias: {
 				style: source('style'),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Feature: An update to the webpack-base-config.js file

**Did you add tests for your changes?**
No
**Summary**
Currently preact-cli will not allow the import of .wasm files. This update should afford the opportunity to do so.

**Does this PR introduce a breaking change?**
It shouldn't

**Other information**
N/A