### PR TITLE
Fix dev server `clientLogLevel`

### DIFF
--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -324,7 +324,7 @@ function isDev(config) {
 			disableHostCheck: true,
 			historyApiFallback: true,
 			quiet: true,
-			clientLogLevel: 'none',
+			clientLogLevel: 'silent',
 			overlay: false,
 			stats: 'minimal',
 			watchOptions: {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -126,7 +126,7 @@
     "validate-npm-package-name": "^3.0.0",
     "webpack": "^4.29.6",
     "webpack-bundle-analyzer": "^3.3.2",
-    "webpack-dev-server": "^3.3.1",
+    "webpack-dev-server": "^3.4.0",
     "webpack-fix-style-only-entries": "^0.2.1",
     "webpack-merge": "^4.1.0",
     "webpack-plugin-replace": "^1.2.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

:bug: fix

**Did you add tests for your changes?**

N/A

**Summary**

In `webpack-dev-server` v3.4.0, the `clientLogLevel` value of `none` was removed and replaced with `silent`. As v3.4.0 falls in `preact-cli`'s range of `^3.3.1`, and `webpack-dev-server` strictly validates its options before starting, this should be causing `preact watch` to fail if the project was created after said dev server version was published.

See https://github.com/webpack/webpack-dev-server/pull/1825

**Does this PR introduce a breaking change?**

No (other than bumping `webpack-dev-server`, which could be considered a breaking change, and probably should have on their part).

**Other information**

```
specs -m
Host: XPS 13 9370 
OS: Manjaro Linux x86_64 
Kernel: Linux 5.0.9-2-MANJARO 
CPU: Intel i7-8550U (8) @ 4.0GHz 
GPU: Intel UHD Graphics 620

node -v
v11.15.0

npm -v
6.9.0

yarn -v
1.16.0
```